### PR TITLE
35 프로젝트별 대시보드 기능 구현

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 const RootLayout = (props: { children: React.ReactNode }) => {
   const { children } = props;
-  const useMsw = process.env.USE_MSW === "false";
+  const useMsw = process.env.USE_MSW === "true";
   return (
     <html suppressHydrationWarning>
       <body>{useMsw ? <MSWComponent>{children}</MSWComponent> : children}</body>

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -2,13 +2,13 @@ import axiosInstance from "./axiosInstance";
 import { BoardResponse, ProjectProps } from "@/src/types";
 
 export const fetchProjects = async (
-  query: string = "", // 검색어
+  keyword: string = "", // 검색어
   filter: string = "", // 필터링 값
   currentPage: number,
   pageSize: number
 ): Promise<BoardResponse<ProjectProps>> => {
   const response = await axiosInstance.get("/projects", {
-    params: { query, filter, currentPage, pageSize },
+    params: { keyword, filter, currentPage, pageSize },
   });
   return response.data;
 };
@@ -28,16 +28,16 @@ export const fetchProjectsStatusCount = async () => {
   return response.data;
 }
 
-export const fetchProjectTasks = async (
-  projectId: string, 
-  query:string = "", // 검색어 
-  boardStatus:string="", // 게시글 유형
-  boardCategory:string="", // 진행단계
+export const fetchProjectBoard = async (
+  projectId: string,
+  keyword: string = "",
+  boardCategory:string = "", // 게시글 유형
+  boardStatus:string = "", // 게시글 상태
   currentPage: number, // 현재 페이지
   pageSize: number, // 페이지 크기
 ) => {
   const response = await axiosInstance.get(`/projects/${projectId}/tasks`, {
-    params: {query, boardStatus, boardCategory, currentPage, pageSize},
+    params: {keyword, boardStatus, boardCategory, currentPage, pageSize},
   });
   return response.data;
 }

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,12 +1,12 @@
 import axiosInstance from "./axiosInstance";
-import { BoardResponse, ProjectProps } from "@/src/types";
+import { BoardResponseType, ProjectPropsType } from "@/src/types";
 
 export const fetchProjects = async (
   keyword: string = "", // 검색어
   filter: string = "", // 필터링 값
   currentPage: number,
   pageSize: number
-): Promise<BoardResponse<ProjectProps>> => {
+): Promise<BoardResponseType<ProjectPropsType>> => {
   const response = await axiosInstance.get("/projects", {
     params: { keyword, filter, currentPage, pageSize },
   });

--- a/src/components/common/BoardCategorySelectBox.tsx
+++ b/src/components/common/BoardCategorySelectBox.tsx
@@ -1,0 +1,60 @@
+import {
+  SelectContent,
+  SelectItem,
+  SelectRoot,
+  SelectTrigger,
+  SelectValueText,
+} from "@/src/components/ui/select";
+import { useProjectBoard } from "@/src/hook/useProjectBoard";
+import { createListCollection } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+
+const boardCategoryFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "질문", value: "QUESTION" },
+    { label: "요청", value: "REQUEST" },
+    { label: "답변", value: "ANSWER" },
+  ],
+});
+
+export default function BoardCategorySelectBox() {
+  const router = useRouter();
+  const { boardCategory } = useProjectBoard();
+
+  const handleValueChange = (details: { value: string[] }) => {
+    const selectedValue = details.value[0]; // 선택된 첫 번째 값
+    const params = new URLSearchParams(window.location.search);
+
+    if (selectedValue) {
+      params.set("filter", selectedValue); // 필터값 설정
+    } else {
+      params.delete("filter"); // 필터값 제거
+    }
+
+    router.push(`?${params.toString()}`); // URL 업데이트
+  };
+
+  return (
+    <SelectRoot
+      collection={boardCategoryFramework}
+      size="md"
+      width="110px"
+      value={[boardCategory]}
+      onValueChange={handleValueChange}>
+      <SelectTrigger>
+        <SelectValueText></SelectValueText>
+      </SelectTrigger>
+      <SelectContent>
+        {boardCategoryFramework.items.map((status) => (
+          <SelectItem item={status} key={status.value}>
+            {status.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </SelectRoot>
+  );
+}

--- a/src/components/common/BoardSearchSection.tsx
+++ b/src/components/common/BoardSearchSection.tsx
@@ -1,24 +1,27 @@
+"useClient";
+
 import { HStack, Input, Button, Box, Flex } from "@chakra-ui/react";
 import { ChangeEvent, KeyboardEvent, useState } from "react";
-import SelectBox from "./SelectBox";
-import { useProjectList } from "@/src/hook/useProjectList";
 import { useRouter } from "next/navigation";
+import { useProjectBoard } from "@/src/hook/useProjectBoard";
+import BoardCategorySelectBox from "./BoardCategorySelectBox";
+import BoardStatusSelectBox from "./BoardStatusSelectBox";
 
 export default function ProjectsSearchSection() {
   const [input, setInput] = useState<string>();
-  const { query, fetchProjectList } = useProjectList();
+  const { keyword, fetchBoardList } = useProjectBoard();
   const router = useRouter();
 
   // 검색 버튼을 클릭하거나 엔터 입력시 데이터를 가져오는 함수
   const onSubmit = () => {
-    if (!input || query === input) return;
+    if (!input || keyword === input) return;
     // URL 업데이트
     const params = new URLSearchParams(window.location.search);
     params.set("query", input); // 검색어 추가
     router.push(`?${params.toString()}`);
 
     // 데이터 다시 가져오기
-    fetchProjectList(1, 5); // 첫 페이지 데이터 로드
+    fetchBoardList(1, 5); // 첫 페이지 데이터 로드
   };
 
   // 검색어와 필터 상태값 초기화 함수
@@ -26,7 +29,7 @@ export default function ProjectsSearchSection() {
     // URL 쿼리스트링 초기화
     router.push("?");
     setInput("");
-    fetchProjectList(1, 5); // 첫 페이지로 리셋
+    fetchBoardList(1, 5); // 첫 페이지로 리셋
   };
 
   // 사용자가 input 태그에 이력하는 값을 실시간으로 query state에 보관
@@ -42,10 +45,11 @@ export default function ProjectsSearchSection() {
   };
 
   return (
-    <Box>
+    <Box mb="10px">
       <Flex gap={4} alignItems="center" justifyContent="end">
         <HStack>
-          <SelectBox />
+          <BoardStatusSelectBox />
+          <BoardCategorySelectBox />
           <Input
             placeholder="프로젝트명 검색"
             size="md"

--- a/src/components/common/BoardStatusSelectBox.tsx
+++ b/src/components/common/BoardStatusSelectBox.tsx
@@ -5,26 +5,26 @@ import {
   SelectTrigger,
   SelectValueText,
 } from "@/src/components/ui/select";
-import { useProjectList } from "@/src/hook/useProjectList";
-import { createListCollection, ListCollection } from "@chakra-ui/react";
+import { useProjectBoard } from "@/src/hook/useProjectBoard";
+import { createListCollection } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 
-const frameworks = createListCollection<{ label: string; value: string }>({
+const boardStatusFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
   items: [
     { label: "전체", value: "" },
-    // { label: "계약", value: "계약" },
-    { label: "진행중", value: "IN_PROGRESS" },
-    { label: "납품완료", value: "COMPLETED" },
-    // { label: "하자보수", value: "하자보수" },
-    { label: "일시중단", value: "PAUSED" },
-    // { label: "삭제(관리자용)", value: "삭제(관리자용)" },
+    { label: "진행중", value: "PROGRESS" },
+    { label: "완료", value: "COMPLETED" },
+    { label: "보류", value: "SUSPENSION" },
+    { label: "승인요청", value: "PERMISSION_REQUEST" },
   ],
 });
 
-export default function SelectBox() {
+export default function BoardStatusSelectBox() {
   const router = useRouter();
-
-  const { filter } = useProjectList();
+  const { boardStatus } = useProjectBoard();
 
   const handleValueChange = (details: { value: string[] }) => {
     const selectedValue = details.value[0]; // 선택된 첫 번째 값
@@ -41,16 +41,16 @@ export default function SelectBox() {
 
   return (
     <SelectRoot
-      collection={frameworks}
+      collection={boardStatusFramework}
       size="md"
       width="110px"
-      value={[filter]}
+      value={[boardStatus]}
       onValueChange={handleValueChange}>
       <SelectTrigger>
         <SelectValueText></SelectValueText>
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((status) => (
+        {boardStatusFramework.items.map((status) => (
           <SelectItem item={status} key={status.value}>
             {status.label}
           </SelectItem>

--- a/src/components/common/CommonTable.tsx
+++ b/src/components/common/CommonTable.tsx
@@ -36,7 +36,7 @@ const CommonTable = <T extends { id: number }>({
             </Table.Cell>
           </Table.Row>
         ) : (
-          data.map((item) => (
+          data?.map((item) => (
             <Table.Row
               key={item.id}
               onClick={() => handleRowClick(item.id)}

--- a/src/components/common/CommonTable.tsx
+++ b/src/components/common/CommonTable.tsx
@@ -7,14 +7,14 @@ import { useRouter } from "next/navigation";
 
 interface CommonTableProps<T> {
   headerTitle: ReactNode;
-  projectList: T[];
+  data: T[];
   loading: boolean;
   renderRow: (item: T) => ReactNode;
 }
 
 const CommonTable = <T extends { id: number }>({
   headerTitle,
-  projectList,
+  data,
   loading,
   renderRow,
 }: CommonTableProps<T>) => {
@@ -36,10 +36,10 @@ const CommonTable = <T extends { id: number }>({
             </Table.Cell>
           </Table.Row>
         ) : (
-          projectList.map((project) => (
+          data.map((item) => (
             <Table.Row
-              key={project.id}
-              onClick={() => handleRowClick(project.id)}
+              key={item.id}
+              onClick={() => handleRowClick(item.id)}
               css={{
                 "& > td": {
                   textAlign: "center",
@@ -48,7 +48,7 @@ const CommonTable = <T extends { id: number }>({
                   cursor: "pointer",
                 },
               }}>
-              {renderRow(project)}
+              {renderRow(item)}
             </Table.Row>
           ))
         )}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,8 +1,8 @@
 import { HStack, Button } from "@chakra-ui/react";
-import { PaginationInfo } from "@/src/types";
+import { PaginationInfoType } from "@/src/types";
 
 interface PaginationProps {
-  paginationInfo?: PaginationInfo; // PaginationMeta 전체를 전달받음
+  paginationInfo?: PaginationInfoType; // PaginationMeta 전체를 전달받음
   handlePageChange: (page: number) => void; // 페이지 변경 핸들러
 }
 

--- a/src/components/common/ProgressStepButton.tsx
+++ b/src/components/common/ProgressStepButton.tsx
@@ -1,5 +1,4 @@
 import { Button, Text } from "@chakra-ui/react";
-import { useState } from "react";
 
 interface ProgressStepButtonProps {
   text: string;

--- a/src/components/common/ProgressStepSection.tsx
+++ b/src/components/common/ProgressStepSection.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { Box, Flex } from "@chakra-ui/react";
-import { Loading } from "./Loading";
-import { useProgressData } from "@/src/hook/useProgressData";
+import { Flex } from "@chakra-ui/react";
 import ProgressStepButton from "./ProgressStepButton";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface ProgressStepSectionProps {
   projectId: string;

--- a/src/components/common/ProjectStatusSelectBox.tsx
+++ b/src/components/common/ProjectStatusSelectBox.tsx
@@ -1,0 +1,57 @@
+import {
+  SelectContent,
+  SelectItem,
+  SelectRoot,
+  SelectTrigger,
+  SelectValueText,
+} from "@/src/components/ui/select";
+import { useProjectList } from "@/src/hook/useProjectList";
+import { createListCollection } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+
+const projectStatus = createListCollection<{ label: string; value: string }>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "진행중", value: "IN_PROGRESS" },
+    { label: "납품완료", value: "COMPLETED" },
+    { label: "일시중단", value: "PAUSED" },
+  ],
+});
+
+export default function ProjectStatusSelectBox() {
+  const router = useRouter();
+  const { filter } = useProjectList();
+
+  const handleValueChange = (details: { value: string[] }) => {
+    const selectedValue = details.value[0]; // 선택된 첫 번째 값
+    const params = new URLSearchParams(window.location.search);
+
+    if (selectedValue) {
+      params.set("filter", selectedValue); // 필터값 설정
+    } else {
+      params.delete("filter"); // 필터값 제거
+    }
+
+    router.push(`?${params.toString()}`); // URL 업데이트
+  };
+
+  return (
+    <SelectRoot
+      collection={projectStatus}
+      size="md"
+      width="110px"
+      value={[filter]}
+      onValueChange={handleValueChange}>
+      <SelectTrigger>
+        <SelectValueText></SelectValueText>
+      </SelectTrigger>
+      <SelectContent>
+        {projectStatus.items.map((status) => (
+          <SelectItem item={status} key={status.value}>
+            {status.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </SelectRoot>
+  );
+}

--- a/src/components/common/ProjectsSearchSection.tsx
+++ b/src/components/common/ProjectsSearchSection.tsx
@@ -1,20 +1,20 @@
 import { HStack, Input, Button, Box, Flex } from "@chakra-ui/react";
 import { ChangeEvent, KeyboardEvent, useState } from "react";
-import SelectBox from "./SelectBox";
+import ProjectStatusSelectBox from "./ProjectStatusSelectBox";
 import { useProjectList } from "@/src/hook/useProjectList";
 import { useRouter } from "next/navigation";
 
 export default function ProjectsSearchSection() {
-  const [input, setInput] = useState<string>();
-  const { query, fetchProjectList } = useProjectList();
+  const [input, setInput] = useState<string>("");
+  const { keyword, fetchProjectList } = useProjectList();
   const router = useRouter();
 
   // 검색 버튼을 클릭하거나 엔터 입력시 데이터를 가져오는 함수
   const onSubmit = () => {
-    if (!input || query === input) return;
+    if (!input || keyword === input) return;
     // URL 업데이트
     const params = new URLSearchParams(window.location.search);
-    params.set("query", input); // 검색어 추가
+    params.set("keyword", input); // 검색어 추가
     router.push(`?${params.toString()}`);
 
     // 데이터 다시 가져오기
@@ -45,7 +45,7 @@ export default function ProjectsSearchSection() {
     <Box>
       <Flex gap={4} alignItems="center" justifyContent="end">
         <HStack>
-          <SelectBox />
+          <ProjectStatusSelectBox />
           <Input
             placeholder="프로젝트명 검색"
             size="md"

--- a/src/components/common/ProjectsStatusCards.tsx
+++ b/src/components/common/ProjectsStatusCards.tsx
@@ -2,10 +2,7 @@
 
 import { Box, Flex, Heading } from "@chakra-ui/react";
 import StatusCard from "./ProjectsStatusCard";
-import { ReactNode, useEffect, useState } from "react";
-import { Loading } from "./Loading";
 import { Folder, PackageCheck, Signature, Swords, Wrench } from "lucide-react";
-import { fetchProjectsStatusCount } from "@/src/api/projects";
 
 interface StatusCardsProps {
   title: string;

--- a/src/components/common/SidebarTab.tsx
+++ b/src/components/common/SidebarTab.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Card,
-  CardBody,
-  CardHeader,
-  CardRoot,
-  CardTitle,
-  Separator,
-} from "@chakra-ui/react";
+import { Box, CardBody, CardTitle } from "@chakra-ui/react";
 import Data from "@/src/data/projects_mock_data.json";
 import Link from "next/link";
 import { useSidebar } from "@/src/context/SidebarContext";

--- a/src/components/common/TaskContent.tsx
+++ b/src/components/common/TaskContent.tsx
@@ -21,7 +21,12 @@ const TaskContent = ({ task }: { task: Task }) => {
       if (block.type === "image" && typeof block.data === "object") {
         return (
           <Box key={index} mb={4}>
-            <Image src={block.data.src} borderRadius="md" mb={2} />
+            <Image
+              src={block.data.src}
+              alt="대체 텍스트"
+              borderRadius="md"
+              mb={2}
+            />
           </Box>
         );
       }
@@ -42,8 +47,7 @@ const TaskContent = ({ task }: { task: Task }) => {
         cursor="pointer"
         color={"blue"}
         onClick={() => window.open(link.url, "_blank")}
-        _hover={{ textDecoration: "underline" }}
-      >
+        _hover={{ textDecoration: "underline" }}>
         <Text fontWeight="normal">{link.name}</Text>
       </Box>
     ));
@@ -74,8 +78,7 @@ const TaskContent = ({ task }: { task: Task }) => {
             }
             onMouseLeave={(e) =>
               (e.currentTarget.style.textDecoration = "none")
-            }
-          >
+            }>
             {fileName}
           </a>
         </Box>
@@ -105,19 +108,16 @@ const TaskContent = ({ task }: { task: Task }) => {
         {task.title}
       </Text>
 
-
       {/* 작성자, 작성 일시 */}
       <Box mb={4}>
-      <Text>
-          작성자: {task.author}
-        </Text>
+        <Text>작성자: {task.author}</Text>
         <Text>{formatDateString(task.regAt)}</Text>
       </Box>
 
       {/* 본문 내용 */}
       <Box mb={4}>{renderContent(task.content)}</Box>
-      <br/>
-      <br/>
+      <br />
+      <br />
       {/* 첨부 링크 */}
       <Box>
         <Text fontWeight="bold" mb={2}>
@@ -125,8 +125,8 @@ const TaskContent = ({ task }: { task: Task }) => {
           <VStack align="start">{renderLinks(task.taskBoardLinkList)}</VStack>
         </Text>
       </Box>
-      <br/>
-      <br/>
+      <br />
+      <br />
       {/* 첨부 파일 */}
       <Box mb={4}>
         <Text fontWeight="bold" mb={2}>

--- a/src/components/common/backButton.tsx
+++ b/src/components/common/backButton.tsx
@@ -1,18 +1,13 @@
 import { Box, Button } from "@chakra-ui/react";
 import { BiArrowBack } from "react-icons/bi";
-import { useRouter } from "next/router";
 
 const BackButton = () => (
-
-
   <Box position={"relative"} w={"100"} mb={4}>
     <Button
-
       bg={"white"}
       color={"black"}
       colorScheme={"blackAlpha"}
-      _hover={{ bg: "blackAlpha.300" }}
-    >
+      _hover={{ bg: "blackAlpha.300" }}>
       <BiArrowBack />
     </Button>
   </Box>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -22,8 +22,12 @@ function Header() {
           throw new Error("User 정보가 로컬스토리지에 없습니다.");
         }
         const userObject = JSON.parse(userData);
-        const foundMember = membersData.data.find(member => member.id === userObject.id);
-        const foundOrg = orgsData.data.find(org => org.id === foundMember?.org_id);
+        const foundMember = membersData.data.find(
+          (member) => member.id === userObject.id
+        );
+        const foundOrg = orgsData.data.find(
+          (org) => org.id === foundMember?.org_id
+        );
         if (foundMember && foundOrg) {
           setUser({
             id: foundMember.id,
@@ -46,7 +50,14 @@ function Header() {
   }, []);
 
   return (
-    <Flex as="nav" align="center" justify="space-between" wrap="wrap" padding="1rem" backgroundColor="gray.200" boxShadow="md">
+    <Flex
+      as="nav"
+      align="center"
+      justify="space-between"
+      wrap="wrap"
+      padding="1rem"
+      backgroundColor="gray.200"
+      boxShadow="md">
       <Flex align="center" mr={5}>
         <Link href="/">
           <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
@@ -58,7 +69,15 @@ function Header() {
       <Drawer />
 
       {/* Avatar */}
-      {user && <Profile id={user.id} userName={user.userName} orgName={user.orgName} jobRole={user.jobRole} profile_image_url={user.profile_image_url} isSidebar={false} isAdmin={user.isAdmin} />}
+      {user && (
+        <Profile
+          id={user.id}
+          userName={user.userName}
+          orgName={user.orgName}
+          jobRole={user.jobRole}
+          profile_image_url={user.profile_image_url}
+        />
+      )}
     </Flex>
   );
 }

--- a/src/components/pages/AdminDashboardPage/index.tsx
+++ b/src/components/pages/AdminDashboardPage/index.tsx
@@ -18,6 +18,14 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 export default function ProjectsPage() {
+  return (
+    <Suspense>
+      <ProjectsPageContent />
+    </Suspense>
+  );
+}
+
+function ProjectsPageContent() {
   const { projectList, paginationInfo, loading, fetchProjectList } =
     useProjectList();
   const router = useRouter();
@@ -65,7 +73,7 @@ export default function ProjectsPage() {
               <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
             </Table.Row>
           }
-          projectList={projectList}
+          data={projectList}
           loading={loading}
           renderRow={(project) => (
             <>

--- a/src/components/pages/AdminDashboardPage/index.tsx
+++ b/src/components/pages/AdminDashboardPage/index.tsx
@@ -1,42 +1,97 @@
-import { Heading, Table } from "@chakra-ui/react";
-import BasicTable from "@/src/components/common/ProjectsList";
+"use client";
+
+import { Heading, Stack, Table } from "@chakra-ui/react";
 import ProjectStatusCards from "@/src/components/common/ProjectsStatusCards";
 import Head from "next/head";
-import { ProjectsFilterProvider } from "@/src/context/ProjectsFilterContext";
+import CommonTable from "../../common/CommonTable";
+import ProjectsSearchSection from "../../common/ProjectsSearchSection";
+import { CustomBox } from "../../common/CustomBox";
+import Pagination from "../../common/Pagination";
+import { useProjectList } from "@/src/hook/useProjectList";
+import { useRouter } from "next/navigation";
+import { Suspense } from "react";
 
-export default function AdminDashboardPage() {
+const STATUS_LABELS: Record<string, string> = {
+  IN_PROGRESS: "진행중",
+  PAUSED: "일시 중단",
+  COMPLETED: "완료",
+};
+
+export default function ProjectsPage() {
+  const { projectList, paginationInfo, loading, fetchProjectList } =
+    useProjectList();
+  const router = useRouter();
+
+  // 페이지 변경 시 새로운 데이터를 가져오는 함수
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(window.location.search);
+    // 쿼리스트링 업데이트
+    params.set("page", page.toString());
+    // URL 업데이트
+    router.push(`?${params.toString()}`);
+    // 데이터를 다시 가져오기
+    fetchProjectList(page, paginationInfo?.pageSize || 5);
+  };
+
   return (
-    <ProjectsFilterProvider>
+    <>
       <Head>
         <title>FlowSync</title>
         <meta property="og:image" content="@/public/FlowSyncLogo.jpg" />
         <meta property="og:title" content="FlowSync" />
-        <meta property="og:description" content="FlowSync로 프로젝트 관리를 한번에" />
+        <meta
+          property="og:description"
+          content="FlowSync로 프로젝트 관리를 한번에"
+        />
       </Head>
       <ProjectStatusCards title={"프로젝트 현황"} />
-      <Heading size="2xl" color="gray.600">
-        프로젝트 목록
-      </Heading>
-      <BasicTable
-        headerTitle={
-          <Table.Row
-            backgroundColor={"#eee"}
-            css={{
-              "& > th": {
-                // 모든 자식 `th` 태그에 스타일 적용
-                textAlign: "center",
-              },
-            }}
-          >
-            <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
-            <Table.ColumnHeader>고객사</Table.ColumnHeader>
-            <Table.ColumnHeader>개발사</Table.ColumnHeader>
-            <Table.ColumnHeader>프로젝트 상태</Table.ColumnHeader>
-            <Table.ColumnHeader>프로젝트 시작일</Table.ColumnHeader>
-            <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
-          </Table.Row>
-        }
-      />
-    </ProjectsFilterProvider>
+      <Stack width="full">
+        <Heading size="2xl" color="gray.600">
+          프로젝트 목록
+        </Heading>
+        <ProjectsSearchSection />
+        <CommonTable
+          headerTitle={
+            <Table.Row
+              backgroundColor={"#eee"}
+              css={{
+                "& > th": { textAlign: "center" },
+              }}>
+              <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
+              <Table.ColumnHeader>고객사</Table.ColumnHeader>
+              <Table.ColumnHeader>개발사</Table.ColumnHeader>
+              <Table.ColumnHeader>프로젝트 상태</Table.ColumnHeader>
+              <Table.ColumnHeader>프로젝트 시작일</Table.ColumnHeader>
+              <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
+            </Table.Row>
+          }
+          projectList={projectList}
+          loading={loading}
+          renderRow={(project) => (
+            <>
+              <Table.Cell>{project.name}</Table.Cell>
+              <Table.Cell>{project.customerName}</Table.Cell>
+              <Table.Cell>{project.developerName}</Table.Cell>
+              <Table.Cell>
+                <CustomBox>
+                  {STATUS_LABELS[project.status] || "알 수 없음"}
+                </CustomBox>
+              </Table.Cell>
+              <Table.Cell>{project.startAt}</Table.Cell>
+              <Table.Cell>{project.closeAt}</Table.Cell>
+            </>
+          )}
+        />
+        <Pagination
+          paginationInfo={
+            paginationInfo && {
+              ...paginationInfo,
+              currentPage: paginationInfo.currentPage + 1,
+            }
+          }
+          handlePageChange={handlePageChange}
+        />
+      </Stack>
+    </>
   );
 }

--- a/src/components/pages/LoginPage/index.tsx
+++ b/src/components/pages/LoginPage/index.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { useRedirectIfLoggedIn } from "@/src/hook/useRedirectIfLoggedIn";
-import { Box, Button, Flex, Heading, HStack, Separator, Span, Text } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  Separator,
+  Span,
+  Text,
+} from "@chakra-ui/react";
+import React, { useState } from "react";
 import { login } from "@/src/api/auth";
 import LoginInputForm from "../../common/LoginInputForm";
 import Link from "next/link";
@@ -43,28 +52,74 @@ export default function LoginPage() {
   };
 
   return (
-    <Flex direction="column" align="center" justify="center" minH="100vh" padding="1.5" bg="gray.50">
+    <Flex
+      direction="column"
+      align="center"
+      justify="center"
+      minH="100vh"
+      padding="1.5"
+      bg="gray.50">
       {/* 제목 */}
-      <Flex direction="column" align="center" fontWeight="medium" gap="2.5" marginBottom="8">
+      <Flex
+        direction="column"
+        align="center"
+        fontWeight="medium"
+        gap="2.5"
+        marginBottom="8">
         <Span fontSize="8xl">📄</Span>
         <Heading fontSize="4xl" fontWeight="medium">
           BN SYSTEM
         </Heading>
-        <Heading fontSize="lg" fontWeight="medium" color="gray.600" textAlign="center">
+        <Heading
+          fontSize="lg"
+          fontWeight="medium"
+          color="gray.600"
+          textAlign="center">
           기업 회원 전용 페이지에 오신 것을 환영합니다!
         </Heading>
       </Flex>
 
       {/* 로그인 폼 */}
-      <Box display="flex" flexDirection="column" width="90%" maxW="400px" padding="6" border="1px" borderColor="gray.300" borderRadius="md" bg="white" boxShadow="sm" gap="3">
+      <Box
+        display="flex"
+        flexDirection="column"
+        width="90%"
+        maxW="400px"
+        padding="6"
+        border="1px"
+        borderColor="gray.300"
+        borderRadius="md"
+        bg="white"
+        boxShadow="sm"
+        gap="3">
         <form onSubmit={handleSubmit}>
           <Flex direction="column" align="center" gap="2">
-            <LoginInputForm id="email" type="email" label="Email address" placeholder="이메일을 입력하세요." onChange={e => handleChange("email", e.target.value)} />
-            <LoginInputForm id="password" type="password" label="Password" placeholder="패스워드를 입력하세요." onChange={e => handleChange("password", e.target.value)} />
+            <LoginInputForm
+              id="email"
+              type="email"
+              label="Email address"
+              placeholder="이메일을 입력하세요."
+              onChange={(e) => handleChange("email", e.target.value)}
+            />
+            <LoginInputForm
+              id="password"
+              type="password"
+              label="Password"
+              placeholder="패스워드를 입력하세요."
+              onChange={(e) => handleChange("password", e.target.value)}
+            />
 
             {error && <span style={{ color: "red" }}>{error}</span>}
 
-            <Button type="submit" backgroundColor="#00a8ff" color="white" fontSize="lg" fontWeight="medium" width="100%" disabled={isLoading} _hover={{ backgroundColor: "#007acc" }}>
+            <Button
+              type="submit"
+              backgroundColor="#00a8ff"
+              color="white"
+              fontSize="lg"
+              fontWeight="medium"
+              width="100%"
+              disabled={isLoading}
+              _hover={{ backgroundColor: "#007acc" }}>
               로그인
             </Button>
           </Flex>

--- a/src/components/pages/ProjectPage/index.tsx
+++ b/src/components/pages/ProjectPage/index.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { Box, Flex, Heading, HStack, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Table, Text } from "@chakra-ui/react";
 import { SegmentedControl } from "../../ui/segmented-control";
 import { Layers, List } from "lucide-react";
 import ProjectInfo from "../../common/ProjectInfo";
 import ProgressStepSection from "../../common/ProgressStepSection";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import BoardSearchSection from "../../common/BoardSearchSection";
+import CommonTable from "../../common/CommonTable";
+import { useProjectBoard } from "@/src/hook/useProjectBoard";
+import { CustomBox } from "../../common/CustomBox";
 
 interface ProjectPageProps {
   params: Promise<{ projectId: string }>;
@@ -19,12 +22,14 @@ export default function ProjectPage({ params }: ProjectPageProps) {
 
   const [projectId, setProjectId] = useState<string>();
 
-  const getProjectId = async () => {
+  const { boardList, loading } = useProjectBoard();
+
+  const getProjectId = useCallback(async () => {
     setProjectId((await params).projectId);
-  };
+  }, [params]);
   useEffect(() => {
     getProjectId();
-  }, []);
+  }, [getProjectId]);
 
   const projectInfo = {
     projectTitle: "커넥티드에듀",
@@ -93,36 +98,34 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         boxShadow="md"
         mb="30px">
         <BoardSearchSection />
-        {/* <CommonTable
+        <CommonTable
           headerTitle={
             <Table.Row
               backgroundColor={"#eee"}
               css={{
                 "& > th": { textAlign: "center" },
               }}>
-              <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
-              <Table.ColumnHeader>고객사</Table.ColumnHeader>
-              <Table.ColumnHeader>개발사</Table.ColumnHeader>
-              <Table.ColumnHeader>프로젝트 상태</Table.ColumnHeader>
-              <Table.ColumnHeader>프로젝트 시작일</Table.ColumnHeader>
-              <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
+              <Table.ColumnHeader>제목</Table.ColumnHeader>
+              <Table.ColumnHeader>작성일</Table.ColumnHeader>
+              <Table.ColumnHeader>게시글 상태</Table.ColumnHeader>
+              <Table.ColumnHeader>게시글 유형</Table.ColumnHeader>
             </Table.Row>
           }
-          data={projectList}
+          data={boardList}
           loading={loading}
           renderRow={(item) => (
             <>
-              <Table.Cell>{item.projectName}</Table.Cell>
-              <Table.Cell>{item.client}</Table.Cell>
-              <Table.Cell>{item.developer}</Table.Cell>
+              <Table.Cell>{item.title}</Table.Cell>
+              <Table.Cell>{item.regAt}</Table.Cell>
               <Table.Cell>
-                <CustomBox>{item.projectStatus}</CustomBox>
+                <CustomBox>{item.boardStatus}</CustomBox>
               </Table.Cell>
-              <Table.Cell>{item.startAt}</Table.Cell>
-              <Table.Cell>{item.closeAt}</Table.Cell>
+              <Table.Cell>
+                <CustomBox>{item.boardCategory}</CustomBox>
+              </Table.Cell>
             </>
           )}
-        /> */}
+        />
       </Box>
     </>
   );

--- a/src/components/pages/ProjectsPage/index.tsx
+++ b/src/components/pages/ProjectsPage/index.tsx
@@ -9,6 +9,7 @@ import { CustomBox } from "../../common/CustomBox";
 import Pagination from "../../common/Pagination";
 import { useProjectList } from "@/src/hook/useProjectList";
 import { useRouter } from "next/navigation";
+import { Suspense } from "react";
 
 const STATUS_LABELS: Record<string, string> = {
   IN_PROGRESS: "진행중",
@@ -16,7 +17,15 @@ const STATUS_LABELS: Record<string, string> = {
   COMPLETED: "완료",
 };
 
-export default function ProjectsPage() {
+export default function projectsPage() {
+  return (
+    <Suspense>
+      <ProjectsPageContent />
+    </Suspense>
+  );
+}
+
+function ProjectsPageContent() {
   const { projectList, paginationInfo, loading, fetchProjectList } =
     useProjectList();
   const router = useRouter();
@@ -64,7 +73,7 @@ export default function ProjectsPage() {
               <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
             </Table.Row>
           }
-          projectList={projectList}
+          data={projectList}
           loading={loading}
           renderRow={(project) => (
             <>

--- a/src/components/pages/ProjectsPage/index.tsx
+++ b/src/components/pages/ProjectsPage/index.tsx
@@ -16,7 +16,7 @@ const STATUS_LABELS: Record<string, string> = {
   COMPLETED: "완료",
 };
 
-export default function ProjectsPageC() {
+export default function ProjectsPage() {
   const { projectList, paginationInfo, loading, fetchProjectList } =
     useProjectList();
   const router = useRouter();

--- a/src/hook/useProjectBoard.tsx
+++ b/src/hook/useProjectBoard.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useParams, useSearchParams } from "next/navigation";
+import { BoardResponse, PaginationInfo, ProjectProps } from "../types";
+import { useCallback, useEffect, useState } from "react";
+import { fetchProjectBoard } from "../api/projects";
+import { ProjectPost } from "../types";
+
+export function useProjectBoard() {
+  const searchParams = useSearchParams(); // URL 쿼리스트링 추출
+  const { projectId } = useParams(); // 동적 경로 추출
+
+  const [boardList, setBoardList] = useState<ProjectPost[]>([]);
+  const [paginationInfo, setPaginationInfo] = useState<PaginationInfo>();
+  const [loading, setLoading] = useState(false);
+
+  const keyword = searchParams.get("keyword") || "";
+  const boardCategory = searchParams.get("boardCategory") || "";
+  const boardStatus = searchParams.get("boardStatus") || "";
+
+  const fetchBoardList = useCallback(
+    async (currentPage: number = 1, pageSize: number = 5) => {
+      setLoading(true);
+      try {
+        const response: BoardResponse<ProjectPost> = await fetchProjectBoard(
+          projectId as string,
+          keyword,
+          boardStatus,
+          boardCategory,
+          currentPage - 1,
+          pageSize
+        );
+        setBoardList(response.data);
+        setPaginationInfo(response.meta);
+      } catch (error) {
+        console.error("Failed to fetch data:", error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectId, keyword, boardStatus, boardCategory]
+  );
+
+  useEffect(() => {
+    fetchBoardList();
+  }, [fetchBoardList]);
+
+  return {
+    keyword,
+    boardStatus,
+    boardCategory,
+    boardList,
+    paginationInfo,
+    loading,
+    fetchBoardList,
+  };
+}

--- a/src/hook/useProjectBoard.tsx
+++ b/src/hook/useProjectBoard.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useParams, useSearchParams } from "next/navigation";
-import { BoardResponse, PaginationInfo, ProjectProps } from "../types";
+import { BoardResponseType, PaginationInfoType } from "../types";
 import { useCallback, useEffect, useState } from "react";
 import { fetchProjectBoard } from "../api/projects";
-import { ProjectPost } from "../types";
+import { ProjectPostType } from "../types";
 
 export function useProjectBoard() {
   const searchParams = useSearchParams(); // URL 쿼리스트링 추출
   const { projectId } = useParams(); // 동적 경로 추출
 
-  const [boardList, setBoardList] = useState<ProjectPost[]>([]);
-  const [paginationInfo, setPaginationInfo] = useState<PaginationInfo>();
+  const [boardList, setBoardList] = useState<ProjectPostType[]>([]);
+  const [paginationInfo, setPaginationInfo] = useState<PaginationInfoType>();
   const [loading, setLoading] = useState(false);
 
   const keyword = searchParams.get("keyword") || "";
@@ -22,14 +22,15 @@ export function useProjectBoard() {
     async (currentPage: number = 1, pageSize: number = 5) => {
       setLoading(true);
       try {
-        const response: BoardResponse<ProjectPost> = await fetchProjectBoard(
-          projectId as string,
-          keyword,
-          boardStatus,
-          boardCategory,
-          currentPage - 1,
-          pageSize
-        );
+        const response: BoardResponseType<ProjectPostType> =
+          await fetchProjectBoard(
+            projectId as string,
+            keyword,
+            boardStatus,
+            boardCategory,
+            currentPage - 1,
+            pageSize
+          );
         setBoardList(response.data);
         setPaginationInfo(response.meta);
       } catch (error) {

--- a/src/hook/useProjectInfo.tsx
+++ b/src/hook/useProjectInfo.tsx
@@ -37,7 +37,7 @@ export function useProjectInfo(params: Promise<{ projectId: string }>) {
     };
 
     fetchProjectData();
-  }, []);
+  }, [params]);
 
   return { projectId, projectInfo, loading };
 }

--- a/src/hook/useProjectList.tsx
+++ b/src/hook/useProjectList.tsx
@@ -8,7 +8,7 @@ export function useProjectList() {
   const [projectList, setProjectList] = useState<ProjectProps[]>([]);
   const [paginationInfo, setPaginationInfo] = useState<PaginationInfo>();
   const [loading, setLoading] = useState(false);
-  const query = searchParams.get("query") || "";
+  const keyword = searchParams.get("keyword") || "";
   const filter = searchParams.get("filter") || "";
 
   const fetchProjectList = useCallback(
@@ -16,7 +16,7 @@ export function useProjectList() {
       setLoading(true);
       try {
         const response: BoardResponse<ProjectProps> = await fetchProjects(
-          query,
+          keyword,
           filter,
           currentPage - 1,
           pageSize
@@ -29,7 +29,7 @@ export function useProjectList() {
         setLoading(false);
       }
     },
-    [query, filter]
+    [keyword, filter]
   );
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export function useProjectList() {
   }, [fetchProjectList]);
 
   return {
-    query,
+    keyword,
     filter,
     projectList,
     paginationInfo,

--- a/src/hook/useProjectList.tsx
+++ b/src/hook/useProjectList.tsx
@@ -1,12 +1,16 @@
 import { useSearchParams } from "next/navigation";
-import { BoardResponse, PaginationInfo, ProjectProps } from "../types";
+import {
+  BoardResponseType,
+  PaginationInfoType,
+  ProjectPropsType,
+} from "../types";
 import { useCallback, useEffect, useState } from "react";
 import { fetchProjects } from "../api/projects";
 
 export function useProjectList() {
   const searchParams = useSearchParams();
-  const [projectList, setProjectList] = useState<ProjectProps[]>([]);
-  const [paginationInfo, setPaginationInfo] = useState<PaginationInfo>();
+  const [projectList, setProjectList] = useState<ProjectPropsType[]>([]);
+  const [paginationInfo, setPaginationInfo] = useState<PaginationInfoType>();
   const [loading, setLoading] = useState(false);
   const keyword = searchParams.get("keyword") || "";
   const filter = searchParams.get("filter") || "";
@@ -15,12 +19,8 @@ export function useProjectList() {
     async (currentPage: number = 1, pageSize: number = 5) => {
       setLoading(true);
       try {
-        const response: BoardResponse<ProjectProps> = await fetchProjects(
-          keyword,
-          filter,
-          currentPage - 1,
-          pageSize
-        );
+        const response: BoardResponseType<ProjectPropsType> =
+          await fetchProjects(keyword, filter, currentPage - 1, pageSize);
         setProjectList(response.data);
         setPaginationInfo(response.meta);
       } catch (error) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,7 +1,7 @@
-import { PaginationInfo } from './pagination';
+import { PaginationInfoType } from './pagination';
 
 // 공통 API 응답 타입 (리스트 응답)
-export interface BoardResponse<T> {
+export interface BoardResponseType<T> {
   data: T[];              // 응답 데이터
-  meta: PaginationInfo;   // 페이징 메타데이터
+  meta: PaginationInfoType;   // 페이징 메타데이터
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
-export type { PaginationInfo } from './pagination';
-export type { ProjectProps, ProjectInfo, ProjectPost } from './project';
-export type { BoardResponse } from './api';
+export type { PaginationInfoType } from './pagination';
+export type { ProjectPropsType, ProjectInfoType, ProjectPostType } from './project';
+export type { BoardResponseType } from './api';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export type { PaginationInfo } from './pagination';
-export type { ProjectProps, ProjectInfoType } from './project';
+export type { ProjectProps, ProjectInfo, ProjectPost } from './project';
 export type { BoardResponse } from './api';

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,5 +1,5 @@
 // 서버에서 반환되는 페이징 메타데이터 타입
-export interface PaginationInfo {
+export interface PaginationInfoType {
   currentPage: number; // 현재 페이지 번호
   totalPages: number;  // 전체 페이지 수
   pageSize: number;    // 한 페이지당 데이터 개수

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -8,7 +8,7 @@ export interface ProjectProps {
   developerName: string; // 개발사 이름
 }
 
-export interface ProjectInfoType {
+export interface ProjectInfo {
   projectTitle: string; // 프로젝트명
   jobRole: string; // 직무
   profileImageUrl: string; // 프로필 이미지 URL
@@ -17,4 +17,19 @@ export interface ProjectInfoType {
   phoneNum: string; // 담당자 연락처
   projectStartAt: string; // 프로젝트 시작일
   projectCloseAt: string; // 프로젝트 종료일
+}
+
+export interface ProjectPost {
+  id: number, 
+  number:number, 
+  title: string,
+  content: string,
+  regAt: string,
+  editAt: string,
+  approveAt: string,
+  boardCategory:string, // 진행단계
+  boardStatus:string, // 게시글 유형
+  deletedYn: string,
+  currentPage: number, // 현재 페이지
+  pageSize: number, // 페이지 크기
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,4 +1,4 @@
-export interface ProjectProps {
+export interface ProjectPropsType {
   id: number; // 프로젝트 ID
   name: string; // 프로젝트 이름
   status: string; // 계약 단계
@@ -8,7 +8,7 @@ export interface ProjectProps {
   developerName: string; // 개발사 이름
 }
 
-export interface ProjectInfo {
+export interface ProjectInfoType {
   projectTitle: string; // 프로젝트명
   jobRole: string; // 직무
   profileImageUrl: string; // 프로필 이미지 URL
@@ -19,7 +19,7 @@ export interface ProjectInfo {
   projectCloseAt: string; // 프로젝트 종료일
 }
 
-export interface ProjectPost {
+export interface ProjectPostType {
   id: number, 
   number:number, 
   title: string,


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 프로젝트별 대시보드 업무관리 게시판 기능 구현
- Related to #35

### 🔧 What has been changed?

    - 게시판 API 연동(추후 파라미터값 변경)
    - 업무 상태&글 유형을 이용한 필터링 및 제목 검색 기능 구현
    - 프로젝트 기본정보와 진행단계별 개수 시연을 위한 임시 하드코딩
    - 빌드 에러 수정

### 📸 Screenshots / GIFs (if applicable)

![image](https://github.com/user-attachments/assets/ff465e88-1760-47f0-bf50-443533714074)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] 패칭 로직 커스텀 훅 분리 확인
- [ ] 함수형 컴포넌트로 통일
- [ ] 타입 인터페이스 네이밍 뒤에 Type붙여서 통일
- [ ] urlSearchParams() 훅을 쓰는 컴포넌트 <Suspense> 컴포넌트로 감싸기
- [ ] npm run build로 pr 날리기전 확인
