### PR TITLE
72 프로젝트 질문 게시판 api 연동

### DIFF
--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -39,9 +39,9 @@ export async function fetchProjectInfo(projectId: string) {
  * @param projectId 프로젝트 식별자
  * @returns 프로젝트 진행 상황 요약(숫자 형태)
  */
-export async function fetchProjectProgressCount(projectId: string) {
+export async function fetchProjectProgressStep(projectId: string) {
   const response = await axiosInstance.get(
-    `/projects/${projectId}/progressCount`,
+    `/projects/${projectId}/progressStep`,
   );
   return response.data;
 }

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -21,7 +21,7 @@ const Pagination: React.FC<PaginationProps> = ({
   const currentGroup = Math.ceil(currentPage / maxVisibleButtons);
   const startPage = (currentGroup - 1) * maxVisibleButtons + 1;
   const endPage = Math.min(currentGroup * maxVisibleButtons, totalPages);
-
+  console.log({ currentPage, startPage, endPage, totalPages });
   return (
     <HStack wrap="wrap" justify="center" mt={4}>
       {/* 이전 버튼 */}
@@ -37,6 +37,7 @@ const Pagination: React.FC<PaginationProps> = ({
       {/* 페이지 번호 버튼 */}
       {Array.from({ length: endPage - startPage + 1 }, (_, i) => {
         const page = startPage + i;
+        console.log(page);
         return (
           <Button
             size="sm"

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -5,21 +5,19 @@ import { useRouter } from "next/navigation";
 import { HStack, Input, Button, Box, Flex } from "@chakra-ui/react";
 
 interface SearchSectionProps {
-  useCustomHook: () => {
-    keyword: string;
-    fetchBoardList: (page: number, pageSize: number) => void;
-  };
+  keyword: string;
+  fetchBoardList: (page: number, pageSize: number) => void;
   placeholder?: string;
   children?: ReactNode;
 }
 
 export default function SearchSection({
-  useCustomHook,
+  keyword,
+  fetchBoardList,
   placeholder = "검색어를 입력하세요",
   children,
 }: SearchSectionProps) {
   const [input, setInput] = useState<string>();
-  const { keyword, fetchBoardList } = useCustomHook();
   const router = useRouter();
 
   // 검색 버튼을 클릭하거나 엔터 입력시 데이터를 가져오는 함수

--- a/src/components/pages/projectQuestionsPage/index.tsx
+++ b/src/components/pages/projectQuestionsPage/index.tsx
@@ -7,6 +7,8 @@ import { ProjectLayout } from "@/src/components/layouts/ProjectLayout";
 import SearchSection from "@/src/components/common/SearchSection";
 import StatusSelectBox from "@/src/components/common/StatusSelectBox";
 import { useProjectQuestionList } from "@/src/hook/useProjectQuestionList";
+import Pagination from "@/src/components/common/Pagination";
+import { useRouter } from "next/navigation";
 
 const questionStatusFramework = createListCollection<{
   id: string;
@@ -21,17 +23,37 @@ const questionStatusFramework = createListCollection<{
 });
 
 export default function QuestionsPage() {
-  const { projectQuestionList, status, loading } = useProjectQuestionList();
+  const {
+    projectQuestionList,
+    paginationInfo,
+    keyword,
+    status,
+    loading,
+    fetchProjectQuestionList,
+  } = useProjectQuestionList();
+
+  const router = useRouter();
+
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(window.location.search);
+    // 쿼리스트링 업데이트
+    params.set("page", page.toString());
+    // URL 업데이트
+    router.push(`?${params.toString()}`);
+    // 데이터를 다시 가져오기
+    fetchProjectQuestionList(page, paginationInfo?.pageSize || 5);
+  };
 
   const handleRowClick = (id: string) => {
-    console.log("Row clicked:", id);
+    router.push(`/projects/${id}/tasks`);
   };
 
   return (
     <ProjectLayout>
       {/* 검색 섹션 */}
       <SearchSection
-        useCustomHook={useProjectQuestionList}
+        keyword={keyword}
+        fetchBoardList={fetchProjectQuestionList}
         placeholder="제목 입력"
       >
         <StatusSelectBox
@@ -78,6 +100,15 @@ export default function QuestionsPage() {
           </>
         )}
         handleRowClick={handleRowClick}
+      />
+      <Pagination
+        paginationInfo={
+          paginationInfo && {
+            ...paginationInfo,
+            currentPage: paginationInfo.currentPage + 1,
+          }
+        }
+        handlePageChange={handlePageChange}
       />
     </ProjectLayout>
   );

--- a/src/components/pages/projectQuestionsPage/index.tsx
+++ b/src/components/pages/projectQuestionsPage/index.tsx
@@ -37,7 +37,7 @@ export default function QuestionsPage() {
   const handlePageChange = (page: number) => {
     const params = new URLSearchParams(window.location.search);
     // 쿼리스트링 업데이트
-    params.set("page", page.toString());
+    params.set("currentPage", page.toString());
     // URL 업데이트
     router.push(`?${params.toString()}`);
     // 데이터를 다시 가져오기
@@ -105,7 +105,7 @@ export default function QuestionsPage() {
         paginationInfo={
           paginationInfo && {
             ...paginationInfo,
-            currentPage: paginationInfo.currentPage + 1,
+            currentPage: paginationInfo.currentPage,
           }
         }
         handlePageChange={handlePageChange}

--- a/src/components/pages/projectTasksPage/components/ProgressStepSection.tsx
+++ b/src/components/pages/projectTasksPage/components/ProgressStepSection.tsx
@@ -31,7 +31,7 @@ export default function ProgressStepSection({
   projectId,
 }: ProgressStepSectionProps) {
   // 커스텀 훅: 게시판 정보(검색, 필터, 데이터 재조회 등)를 관리
-  const { progressStep, fetchBoardList } = useProjectQuestionList();
+  const { fetchProjectQuestionList } = useProjectQuestionList();
 
   // 현재 선택된 버튼 id 상태 (기본값은 progressData의 첫 번째 항목)
   const [selectedButtonId, setSelectedButtonId] = useState<string>(
@@ -65,7 +65,7 @@ export default function ProgressStepSection({
     history.replaceState(null, "", newUrl); // URL 업데이트
 
     // 새로운 데이터 패치 (boardList 재조회)
-    fetchBoardList();
+    fetchProjectQuestionList();
   };
 
   // const { progressData, loading, error } = useProgressData(projectId);
@@ -78,10 +78,6 @@ export default function ProgressStepSection({
 
   // if (loading) {
   //   return <Loading />; // 로딩 중 표시
-  // }
-
-  // if (error) {
-  //   return <Box>Error: {error}</Box>; // 에러 메시지 표시
   // }
 
   return (

--- a/src/components/pages/projectTasksPage/index.tsx
+++ b/src/components/pages/projectTasksPage/index.tsx
@@ -41,7 +41,7 @@ const dummyData = [
 ];
 
 export default function QuestionsPage() {
-  const { status } = useProjectTaskList();
+  const { keyword, status } = useProjectTaskList();
   const handleRowClick = (id: string) => {
     console.log("Row clicked:", id); // 실제로는 라우팅 처리 가능
   };
@@ -49,7 +49,11 @@ export default function QuestionsPage() {
   return (
     <ProjectLayout>
       {/* 검색 섹션 */}
-      <SearchSection useCustomHook={useProjectTaskList} placeholder="제목 입력">
+      <SearchSection
+        keyword={keyword}
+        fetchBoardList={useProjectTaskList}
+        placeholder="제목 입력"
+      >
         <StatusSelectBox
           statusFramework={taskStatusFramework}
           status={status}

--- a/src/components/pages/projectsPage/index.tsx
+++ b/src/components/pages/projectsPage/index.tsx
@@ -52,8 +52,14 @@ export default function projectsPage() {
 function ProjectsPageContent() {
   // useProjectList 훅: 프로젝트 목록, 페이지 정보, 로딩 상태,
   // 재조회 함수(fetchProjectList) 등을 반환합니다.
-  const { projectList, paginationInfo, status, loading, fetchBoardList } =
-    useProjectList();
+  const {
+    projectList,
+    paginationInfo,
+    keyword,
+    status,
+    loading,
+    fetchProjectList,
+  } = useProjectList();
 
   const router = useRouter();
 
@@ -70,7 +76,7 @@ function ProjectsPageContent() {
     // URL 업데이트
     router.push(`?${params.toString()}`);
     // 데이터를 다시 가져오기
-    fetchBoardList(page, paginationInfo?.pageSize || 5);
+    fetchProjectList(page, paginationInfo?.pageSize || 5);
   };
 
   /**
@@ -111,7 +117,11 @@ function ProjectsPageContent() {
           프로젝트 목록
         </Heading>
         {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
-        <SearchSection useCustomHook={useProjectList} placeholder="제목 입력">
+        <SearchSection
+          keyword={keyword}
+          fetchBoardList={fetchProjectList}
+          placeholder="제목 입력"
+        >
           <StatusSelectBox
             statusFramework={projectStatusFramework}
             status={status}

--- a/src/hook/useMemberList.tsx
+++ b/src/hook/useMemberList.tsx
@@ -48,7 +48,6 @@ export function useMemberList() {
     fetchBoardList();
   }, []);
 
-  console.log("memberList: ", memberList);
   return {
     keyword,
     filter,

--- a/src/hook/useProgressData.tsx
+++ b/src/hook/useProgressData.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchProjectProgressCount } from "@/src/api/projects";
+import { fetchProjectProgressStep as fetchProjectProgressStepApi } from "@/src/api/projects";
 
 /**
  * 프로젝트 진척 정보를 담는 타입 정의
@@ -24,7 +24,7 @@ interface ProgressDataType {
  *   - loading: 로딩 여부
  *   - error: 에러 메시지 (없으면 null)
  */
-export function useProgressData(projectId: string) {
+export function useProgressStep(projectId: string) {
   // 진척 정보 데이터를 저장할 상태
   const [progressData, setProgressData] = useState<ProgressDataType[]>([]);
   // 로딩 상태
@@ -36,14 +36,14 @@ export function useProgressData(projectId: string) {
    * 해당 프로젝트의 단계 데이터를 API로부터 가져옴
    */
   useEffect(() => {
-    const fetchProgressData = async () => {
+    const fetchProgressStep = async () => {
       try {
         setLoading(true);
         setError(null);
 
         // 서버로부터 프로젝트 단계 정보 가져오기
-        const response = await fetchProjectProgressCount(projectId);
-        setProgressData(response);
+        const response = await fetchProjectProgressStepApi(projectId);
+        setProgressData(response.data);
       } catch (err) {
         console.error("Failed to fetch progress data:", err);
         setError(err instanceof Error ? err.message : "Unknown error");
@@ -52,7 +52,7 @@ export function useProgressData(projectId: string) {
       }
     };
 
-    fetchProgressData();
+    fetchProgressStep();
   }, [projectId]);
 
   return { progressData, loading, error };

--- a/src/hook/useProjectList.tsx
+++ b/src/hook/useProjectList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { fetchProjectList } from "@/src/api/projects";
+import { fetchProjectList as fetchProjectListApi } from "@/src/api/projects";
 import {
   CommonResponseType,
   PaginationProps,
@@ -25,12 +25,12 @@ export function useProjectList() {
    * @param currentPage 현재 페이지 (기본값: 1)
    * @param pageSize 페이지 크기 (기본값: 5)
    */
-  const fetchBoardList = useCallback(
+  const fetchProjectList = useCallback(
     async (currentPage: number = 1, pageSize: number = 5) => {
       setLoading(true);
       try {
         const response: CommonResponseType<ProjectListResponse> =
-          await fetchProjectList(keyword, status, currentPage, pageSize);
+          await fetchProjectListApi(keyword, status, currentPage, pageSize);
 
         setProjectList(response.data.projects);
         setPaginationInfo(response.data.meta);
@@ -47,7 +47,7 @@ export function useProjectList() {
    * 컴포넌트 마운트 시 (또는 쿼리 파라미터가 변경될 때) 프로젝트 목록을 가져옴
    */
   useEffect(() => {
-    fetchBoardList();
+    fetchProjectList();
   }, []);
 
   return {
@@ -61,6 +61,6 @@ export function useProjectList() {
     // 로딩 여부
     loading,
     // 직접 페이지를 다시 불러올 때 사용할 수 있는 메서드
-    fetchBoardList,
+    fetchProjectList,
   };
 }

--- a/src/hook/useProjectList.tsx
+++ b/src/hook/useProjectList.tsx
@@ -30,7 +30,7 @@ export function useProjectList() {
       setLoading(true);
       try {
         const response: CommonResponseType<ProjectListResponse> =
-          await fetchProjectList(keyword, status, currentPage - 1, pageSize);
+          await fetchProjectList(keyword, status, currentPage, pageSize);
 
         setProjectList(response.data.projects);
         setPaginationInfo(response.data.meta);

--- a/src/hook/useProjectQuestionList.tsx
+++ b/src/hook/useProjectQuestionList.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { fetchProjectQuestionList } from "@/src/api/projects";
+import { fetchProjectQuestionList as fetchProjectQuestionListAPI } from "@/src/api/projects";
 import {
   CommonResponseType,
   ProjectQuestionProps,
@@ -37,14 +37,14 @@ export function useProjectQuestionList() {
    * @param currentPage 현재 페이지 (기본값: 1)
    * @param pageSize 페이지 크기 (기본값: 5)
    */
-  const fetchBoardList = useCallback(
+  const fetchProjectQuestionList = useCallback(
     async (currentPage: number = 1, pageSize: number = 5) => {
       setLoading(true);
       try {
         // 서버에서 데이터 요청 (검색어, 진행 단계, 게시글 상태, 등)
         // currentPage - 1 : 0-based 페이지 인덱스 사용
         const response: CommonResponseType<ProjectQuestionListResponse> =
-          await fetchProjectQuestionList(
+          await fetchProjectQuestionListAPI(
             projectId as string,
             keyword,
             progressStep,
@@ -66,8 +66,8 @@ export function useProjectQuestionList() {
   );
 
   useEffect(() => {
-    fetchBoardList();
-  }, [fetchBoardList]);
+    fetchProjectQuestionList();
+  }, []);
 
   return {
     keyword, // 검색/필터를 위한 쿼리 파라미터
@@ -82,6 +82,6 @@ export function useProjectQuestionList() {
     projectId, // URL 경로에서 추출한 프로젝트 ID, 태스크 ID
     taskId,
 
-    fetchBoardList, // 게시글 목록 재조회 함수
+    fetchProjectQuestionList, // 게시글 목록 재조회 함수
   };
 }

--- a/src/hook/useProjectQuestionList.tsx
+++ b/src/hook/useProjectQuestionList.tsx
@@ -70,7 +70,7 @@ export function useProjectQuestionList() {
   }, []);
 
   return {
-    keyword, // 검색/필터를 위한 쿼리 파라미터
+    keyword, // 검색 위한 쿼리 파라미터
     progressStep, // 진행 단계
     status, // 글 상태
 


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 프로젝트 질문게시판 API 연동
- Close # 72

### 🔧 What has been changed?
- 프로젝트 질문 게시판 페이지네이션 붙이기
- API 연동
- SearchSection 컴포넌트 속성 변경
- useProjectQuestionList 페치함수 이름 명확하게 변경
- 페이지네이션 + 1되고 있는 버그 수정

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/cd094c91-200b-47c5-98ac-504f1f61e54c)

### ⚠️ Precaution & Known issues
프로젝트 질문 게시판 API 연동 작업 위주로 봐주시면 좋을듯합니다.

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
