### PR TITLE
79 공지사항 UI 제작 및 api 연동

### DIFF
--- a/src/api/notices.ts
+++ b/src/api/notices.ts
@@ -1,0 +1,8 @@
+import { CommonResponseType, NoticeProps } from "@/src/types";
+import axiosInstance from "@/src/api/axiosInstance";
+
+export async function fetchNoticeList(
+): Promise<CommonResponseType<NoticeProps[]>> {
+  const response = await axiosInstance.get("/projects");
+  return response.data;
+}

--- a/src/app/(loggedIn)/notices/page.tsx
+++ b/src/app/(loggedIn)/notices/page.tsx
@@ -1,0 +1,3 @@
+import noticesPage from "@/src/components/pages/noticesPage";
+
+export default noticesPage;

--- a/src/components/pages/ProjectRegisterPage/components/ProjectForm.tsx
+++ b/src/components/pages/ProjectRegisterPage/components/ProjectForm.tsx
@@ -1,82 +1,82 @@
-"use client";
+// "use client";
 
-// 외부 라이브러리
-import React, { useState } from "react";
-import { Box, Input, Text, Flex, Button } from "@chakra-ui/react";
+// // 외부 라이브러리
+// import React, { useState } from "react";
+// import { Box, Input, Text, Flex, Button } from "@chakra-ui/react";
 
-// 절대 경로 파일
-import HeaderSection from "@/src/components/pages/ProjectRegisterPage/components/HeaderSection";
-import DateSection from "@/src/components/pages/ProjectRegisterPage/components/DateSection";
-import ContentSection from "@/src/components/pages/ProjectRegisterPage/components/ContentSection";
-import SelectOrganizationSection from "@/src/components/pages/ProjectRegisterPage/components/SelectOrganizationSection";
+// // 절대 경로 파일
+// import HeaderSection from "@/src/components/pages/ProjectRegisterPage/components/HeaderSection";
+// import DateSection from "@/src/components/pages/ProjectRegisterPage/components/DateSection";
+// import ContentSection from "@/src/components/pages/ProjectRegisterPage/components/ContentSection";
+// import SelectOrganizationSection from "@/src/components/pages/ProjectRegisterPage/components/SelectOrganizationSection";
 
-interface Organization {
-  id: number;
-  type: string;
-  name: string;
-  status: string;
-}
+// interface Organization {
+//   id: number;
+//   type: string;
+//   name: string;
+//   status: string;
+// }
 
-interface Member {
-  id: number;
-  name: string;
-}
+// interface Member {
+//   id: number;
+//   name: string;
+// }
 
-export default function ProjectForm({ id }: { id: string }) {
-  const [name, setName] = useState<string>("");
-  const [status, setStatus] = useState<string>("IN_PROGRESS");
-  const [managementStep, setManagementStep] = useState<string>("CONTRACT");
-  const [startAt, setStartAt] = useState<string>("");
-  const [closeAt, setCloseAt] = useState<string>("");
+// export default function ProjectForm({ id }: { id: string }) {
+//   const [name, setName] = useState<string>("");
+//   const [status, setStatus] = useState<string>("IN_PROGRESS");
+//   const [managementStep, setManagementStep] = useState<string>("CONTRACT");
+//   const [startAt, setStartAt] = useState<string>("");
+//   const [closeAt, setCloseAt] = useState<string>("");
 
-  const [description, setDescription] = useState<string>(""); // 짧은 설명
-  const [detail, setDetail] = useState<string>(""); // 긴 설명
+//   const [description, setDescription] = useState<string>(""); // 짧은 설명
+//   const [detail, setDetail] = useState<string>(""); // 긴 설명
 
-  // const [customerOrganizations, setCustomerOrganizations] = useState<
-  //   Organization[]
-  // >([]);
-  // const [developerOrganizations, setDeveloperOrganizations] = useState<
-  //   Organization[]
-  // >([]);
+//   const [customerOrganizations, setCustomerOrganizations] = useState<
+//     Organization[]
+//   >([]);
+//   const [developerOrganizations, setDeveloperOrganizations] = useState<
+//     Organization[]
+//   >([]);
 
-  // const [selectedCustomer, setSelectedCustomer] = useState<Organization>;
+//   const [selectedCustomer, setSelectedCustomer] = useState<Organization>;
 
-  // 서버에 제출하는 로직 작성 << 해야함
-  const handleSubmit = () => {
-    console.log("제출 완료");
-  };
+//   // 서버에 제출하는 로직 작성 << 해야함
+//   const handleSubmit = () => {
+//     console.log("제출 완료");
+//   };
 
-  return (
-    <Flex direction="column">
-      <Box>
-        <HeaderSection
-          name={name}
-          status={status}
-          managementStep={managementStep}
-          setName={setName}
-          setStatus={setStatus}
-          setManagementStep={setManagementStep}
-        />
-      </Box>
-      <Box>
-        <DateSection
-          startAt={startAt}
-          closeAt={closeAt}
-          setStartAt={setStartAt}
-          setCloseAt={setCloseAt}
-        />
-      </Box>
-      <Box>
-        <ContentSection
-          description={description}
-          detail={detail}
-          setDetail={setDetail}
-          setDescription={setDescription}
-        />
-      </Box>
-      <Box>{/* <SelectOrganizationSection /> */}</Box>
+//   return (
+//     <Flex direction="column">
+//       <Box>
+//         <HeaderSection
+//           name={name}
+//           status={status}
+//           managementStep={managementStep}
+//           setName={setName}
+//           setStatus={setStatus}
+//           setManagementStep={setManagementStep}
+//         />
+//       </Box>
+//       <Box>
+//         <DateSection
+//           startAt={startAt}
+//           closeAt={closeAt}
+//           setStartAt={setStartAt}
+//           setCloseAt={setCloseAt}
+//         />
+//       </Box>
+//       <Box>
+//         <ContentSection
+//           description={description}
+//           detail={detail}
+//           setDetail={setDetail}
+//           setDescription={setDescription}
+//         />
+//       </Box>
+//       <Box>{/* <SelectOrganizationSection /> */}</Box>
 
-      <Button onClick={handleSubmit}>작성</Button>
-    </Flex>
-  );
-}
+//       <Button onClick={handleSubmit}>작성</Button>
+//     </Flex>
+//   );
+// }

--- a/src/components/pages/ProjectRegisterPage/index.tsx
+++ b/src/components/pages/ProjectRegisterPage/index.tsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/backButton";
-import ProjectForm from "@/src/components/pages/ProjectRegisterPage/components/ProjectForm";
+// import ProjectForm from "@/src/components/pages/ProjectRegisterPage/components/ProjectForm";
 import axiosInstance from "@/src/api/axiosInstance";
 
 interface UserInterface {
@@ -41,7 +41,7 @@ export default function ProjectRegisterPage() {
     >
       <BackButton />
 
-      <ProjectForm id={id} />
+      {/* <ProjectForm id={id} /> */}
     </Box>
   );
 }

--- a/src/components/pages/noticesPage/index.tsx
+++ b/src/components/pages/noticesPage/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Heading, Table } from "@chakra-ui/react";
 import CommonTable from "@/src/components/common/CommonTable";
 import { useNoticeList } from "@/src/hook/useNoticeList";

--- a/src/components/pages/noticesPage/index.tsx
+++ b/src/components/pages/noticesPage/index.tsx
@@ -1,0 +1,51 @@
+import { Box, Heading, Table } from "@chakra-ui/react";
+import CommonTable from "@/src/components/common/CommonTable";
+import { useNoticeList } from "@/src/hook/useNoticeList";
+import { useRouter } from "next/navigation";
+import StatusTag from "@/src/components/common/StatusTag";
+
+export default function NoticesPage() {
+  const { noticeList, loading } = useNoticeList();
+
+  const router = useRouter();
+
+  const handleRowClick = (id: string) => {
+    router.push(`/projects/${id}/tasks`);
+  };
+
+  return (
+    <Box>
+      <Heading size="2xl" color="gray.700" mb="10px">
+        공지사항
+      </Heading>
+      <CommonTable
+        headerTitle={
+          <Table.Row
+            backgroundColor={"#eee"}
+            css={{
+              "& > th": { textAlign: "center" },
+            }}
+          >
+            <Table.ColumnHeader>카테고리</Table.ColumnHeader>
+            <Table.ColumnHeader>제목</Table.ColumnHeader>
+            <Table.ColumnHeader>우선순위</Table.ColumnHeader>
+            <Table.ColumnHeader>등록일</Table.ColumnHeader>
+          </Table.Row>
+        }
+        data={noticeList}
+        loading={loading}
+        renderRow={(notice) => (
+          <>
+            <Table.Cell>{notice.category}</Table.Cell>
+            <Table.Cell>{notice.title}</Table.Cell>
+            <Table.Cell>
+              <StatusTag>{notice.priority}</StatusTag>
+            </Table.Cell>
+            <Table.Cell>{notice.regAt}</Table.Cell>
+          </>
+        )}
+        handleRowClick={handleRowClick}
+      />
+    </Box>
+  );
+}

--- a/src/components/pages/projectQuestionsPage/index.tsx
+++ b/src/components/pages/projectQuestionsPage/index.tsx
@@ -32,7 +32,7 @@ const STATUS_LABELS: Record<string, string> = {
   ANSWER: "답변",
 };
 
-export default function QuestionsPage() {
+export default function ProjectQuestionsPage() {
   const {
     projectQuestionList,
     paginationInfo,

--- a/src/components/pages/projectTasksPage/index.tsx
+++ b/src/components/pages/projectTasksPage/index.tsx
@@ -43,7 +43,7 @@ const dummyData = [
   },
 ];
 
-export default function QuestionsPage() {
+export default function ProjectTasksPage() {
   const { keyword, status } = useProjectTaskList();
   const { projectId } = useParams();
   const router = useRouter();

--- a/src/components/pages/projectsPage/index.tsx
+++ b/src/components/pages/projectsPage/index.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { useRouter } from "next/navigation";
 import Head from "next/head";
 import { createListCollection, Heading, Stack, Table } from "@chakra-ui/react";
-import CustomColorBox from "@/src/components/common/StatusTag";
+import StatusTag from "@/src/components/common/StatusTag";
 import { useProjectList } from "@/src/hook/useProjectList";
 import ProjectStatusCards from "@/src/components/pages/projectsPage/components/ProjectsStatusCards";
 import CommonTable from "@/src/components/common/CommonTable";
@@ -159,9 +159,9 @@ function ProjectsPageContent() {
               <Table.Cell>{project.customerName}</Table.Cell>
               <Table.Cell>{project.developerName}</Table.Cell>
               <Table.Cell>
-                <CustomColorBox>
+                <StatusTag>
                   {STATUS_LABELS[project.status] || "알 수 없음"}
-                </CustomColorBox>
+                </StatusTag>
               </Table.Cell>
               <Table.Cell>{project.startAt}</Table.Cell>
               <Table.Cell>{project.closeAt}</Table.Cell>

--- a/src/hook/useNoticeList.tsx
+++ b/src/hook/useNoticeList.tsx
@@ -18,7 +18,7 @@ export function useNoticeList() {
       const response: CommonResponseType<NoticeProps[]> =
         await fetchNoticeListApi();
 
-      setNoticeList(response.data);
+      setNoticeList(Array.isArray(response.data) ? response.data : []);
     } catch (error) {
       console.error("Failed to fetch data:", error);
     } finally {

--- a/src/hook/useNoticeList.tsx
+++ b/src/hook/useNoticeList.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchNoticeList as fetchNoticeListApi } from "@/src/api/notices";
+import { CommonResponseType, NoticeProps } from "@/src/types";
+
+export function useNoticeList() {
+  const [noticeList, setNoticeList] = useState<NoticeProps[]>([]);
+
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * 서버에서 프로젝트 목록을 가져오는 함수
+   * @param currentPage 현재 페이지 (기본값: 1)
+   * @param pageSize 페이지 크기 (기본값: 5)
+   */
+  const fetchNoticeList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response: CommonResponseType<NoticeProps[]> =
+        await fetchNoticeListApi();
+
+      setNoticeList(response.data);
+    } catch (error) {
+      console.error("Failed to fetch data:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * 컴포넌트 마운트 시 (또는 쿼리 파라미터가 변경될 때) 프로젝트 목록을 가져옴
+   */
+  useEffect(() => {
+    fetchNoticeList();
+  }, []);
+
+  return {
+    noticeList,
+    loading,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,7 @@ export interface ProjectProps {
   customerName: string; // 고객사 이름
   developerName: string; // 개발사 이름
 }
+
 export interface ProjectListResponse {
   projects: ProjectProps[];
   meta: PaginationProps; // 페이지네이션 메타 정보
@@ -222,4 +223,22 @@ export interface InputFormData {
   error?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// 공지사항
+export interface NoticeProps {
+  id: string; // 공지사항 ID
+  adminId: string; // 프로젝트 이름
+  title: string; // 계약 단계
+  content: string; // 시작일시
+  category: string; // 시작일시
+  priority: string; // 
+  isDeleted: boolean; // 마감일시
+  regAt: string; // 고객사 이름
+  updatedAt: string; // 개발사 이름
+}
+
+export interface NoticeListResponse {
+  notices: NoticeProps[];
+  meta: PaginationProps; // 페이지네이션 메타 정보
 }


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 공지사항 페이지 간단한 틀 제작
- Related to #79

### 🔧 What has been changed?

- 공지사항 페이지 목록조회용 테이블 UI 구현 및 훅 작성

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/41a0ef80-800c-4e7f-b28b-b7a09c7a9430)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
