### PR TITLE
회원 등록 API 연동

### DIFF
--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -1,9 +1,14 @@
 import axiosInstance from "@/src/api/axiosInstance";
-import { CommonResponseType, MemberListResponse } from "@/src/types";
+import {
+  CommonResponseType,
+  CreateMemberInput,
+  CreateMemberResponse,
+  MemberListResponse,
+} from "@/src/types";
 
 export async function fetchMemberList(
-  keyword: string= "", // 검색키워드
-  role: string="", // 계정타입
+  keyword: string = "", // 검색키워드
+  role: string = "", // 계정타입
   status: string = "", // 활성화여부
   currentPage: number,
   pageSize: number,
@@ -13,4 +18,63 @@ export async function fetchMemberList(
   });
 
   return response.data;
+}
+
+// 회원 생성 API (파일 업로드 X)
+export async function createMember(
+  role: string,
+  organizationId: string,
+  name: string,
+  email: string,
+  password: string,
+  phoneNum: string,
+  jobRole: string,
+  jobTitle: string,
+  introduction: string,
+  remark: string,
+): Promise<CreateMemberInput> {
+  const response = await axiosInstance.post("/admins/members", {
+    role,
+    organizationId,
+    name,
+    email,
+    password,
+    phoneNum,
+    jobRole,
+    jobTitle,
+    introduction,
+    remark,
+  });
+  console.log("회원 등록 API 호출 응답 - response: ", response);
+  console.log("회원 등록 API 호출 응답 - response.data: ", response.data);
+  return response.data; // 생성된 데이터 반환
+}
+
+// 회원 생성 API (파일 업로드 O)
+export async function createMemberWithFile(
+  data: CreateMemberInput,
+  file: any,
+): Promise<CommonResponseType<CreateMemberResponse>> {
+  const formData = new FormData();
+  // content 객체를 JSON 문자열로 변환하여 추가
+  const json = JSON.stringify(data);
+  const blob = new Blob([json], { type: "application/json" });
+  formData.append("content", JSON.stringify(data));
+  formData.append("data", blob);
+
+  // file이 존재할 경우에만 추가
+  formData.append("file", file);
+
+  console.log("회원 등록 API 호출 전 - formData 생성: ", formData);
+
+  // FormData 전송
+  const response = await axiosInstance.post("/admins/members", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  console.log("회원 등록 API 호출 응답 - response: ", response);
+  console.log("회원 등록 API 호출 응답 - response.data: ", response.data);
+  return response.data; // 생성된 데이터 반환
 }

--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -34,7 +34,7 @@ export async function createOrganization(
   // file이 존재할 경우에만 추가
   formData.append("file", file);
 
-  console.log("업체 생성 API 호출 전 - formData 생성: ", formData);
+  console.log("업체 등록 API 호출 전 - formData 생성: ", formData);
 
   // FormData 전송
   const response = await axiosInstance.post("/admins/organizations", formData, {
@@ -43,7 +43,7 @@ export async function createOrganization(
     },
   });
 
-  console.log("업체 생성 API 호출 응답 - response: ", response);
-  console.log("업체 생성 API 호출 응답 - response.data: ", response.data);
+  console.log("업체 등록 API 호출 응답 - response: ", response);
+  console.log("업체 등록 API 호출 응답 - response.data: ", response.data);
   return response.data; // 생성된 데이터 반환
 }

--- a/src/components/pages/adminMembersCreatePage/index.tsx
+++ b/src/components/pages/adminMembersCreatePage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { Box, Flex, HStack } from "@chakra-ui/react";
 import { Radio, RadioGroup } from "@/src/components/ui/radio";
 import { useForm } from "@/src/hook/useForm";
@@ -7,8 +8,10 @@ import InputForm from "@/src/components/common/InputForm";
 import InputFormLayout from "@/src/components/layouts/InputFormLayout";
 import { defaultValuesOfMember } from "@/src/constants/defaultValues";
 import { validationRulesOfCreatingMember } from "@/src/constants/validationRules";
+import { createMember, createMemberWithFile } from "@/src/api/members";
 
 export default function AdminMembersCreatePage() {
+  const route = useRouter();
   const { inputValues, inputErrors, handleInputChange, checkAllInputs } =
     useForm(defaultValuesOfMember, validationRulesOfCreatingMember);
 
@@ -20,13 +23,34 @@ export default function AdminMembersCreatePage() {
     return true;
   }
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!validateInputs()) return;
+    try {
+      const response = await createMember(
+        inputValues.role,
+        inputValues.organizationId,
+        inputValues.name,
+        inputValues.email,
+        inputValues.password,
+        inputValues.phoneNum,
+        inputValues.jobRole,
+        inputValues.jobTitle,
+        inputValues.introduction,
+        inputValues.remark,
+      );
 
-    console.log("폼 제출 성공:", inputValues);
-    alert("업체가 성공적으로 생성되었습니다.");
-    // TODO: 서버로 데이터 전송 로직 추가
+      // 회원 등록 API(2) - 파일 업로드 O
+      // const file = null; // 파일이 있을 경우에만 처리
+      // const response = await createMemberWithFile(memberData, file);
+
+      console.log("회원 등록 성공 - response: ", response);
+      alert("회원이 성공적으로 등록되었습니다.");
+      route.push("/admin/members");
+    } catch (error) {
+      console.error("회원 등록 중 오류 발생:", error);
+      alert("회원 등록에 실패했습니다. 다시 시도해주세요.");
+    }
   }
 
   return (

--- a/src/components/pages/adminMembersPage/index.tsx
+++ b/src/components/pages/adminMembersPage/index.tsx
@@ -2,7 +2,14 @@
 
 import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createListCollection, Heading, Stack, Table } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  createListCollection,
+  Heading,
+  Stack,
+  Table,
+} from "@chakra-ui/react";
 import StatusTag from "@/src/components/common/StatusTag";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
@@ -77,6 +84,11 @@ function AdminMembersPageContent() {
     params: [keyword, role, status, currentPage, pageSize],
   });
 
+  // 신규등록 버튼 클릭 시 - 회원 등록 페이지로 이동
+  const handleMemberCreateButton = () => {
+    router.push("/admin/members/create");
+  };
+
   // 페이지 변경 시 새로운 데이터를 가져오는 함수
   const handlePageChange = (page: number) => {
     const params = new URLSearchParams(window.location.search);
@@ -96,18 +108,27 @@ function AdminMembersPageContent() {
         <Heading size="2xl" color="gray.600">
           회원 관리
         </Heading>
-        <SearchSection keyword={keyword} placeholder="회원명 입력">
-          <FilterSelectBox
-            statusFramework={memberRoleFramework}
-            selectedValue={role}
-            queryKey="role"
-          />
-          <FilterSelectBox
-            statusFramework={memberStatusFramework}
-            selectedValue={status}
-            queryKey="status"
-          />
-        </SearchSection>
+        <Box display="flex" justifyContent="space-between">
+          <SearchSection keyword={keyword} placeholder="회원명 입력">
+            <FilterSelectBox
+              statusFramework={memberRoleFramework}
+              selectedValue={role}
+              queryKey="role"
+            />
+            <FilterSelectBox
+              statusFramework={memberStatusFramework}
+              selectedValue={status}
+              queryKey="status"
+            />
+          </SearchSection>
+          <Button
+            variant={"surface"}
+            _hover={{ backgroundColor: "#00a8ff", color: "white" }}
+            onClick={handleMemberCreateButton}
+          >
+            신규 등록
+          </Button>
+        </Box>
         <CommonTable
           headerTitle={
             <Table.Row

--- a/src/components/pages/adminOrganizationsCreatePage/index.tsx
+++ b/src/components/pages/adminOrganizationsCreatePage/index.tsx
@@ -42,18 +42,18 @@ export default function AdminOrganizationsCreatePage() {
       const file = null; // 파일이 있을 경우에만 처리
 
       const response = await createOrganization(organizationData, file);
-      console.log("업체 생성 성공 - response: ", response);
-      alert("업체가 성공적으로 생성되었습니다.");
+      console.log("업체 등록 성공 - response: ", response);
+      alert("업체가 성공적으로 등록되었습니다.");
       route.push("/admin/organizations");
     } catch (error) {
-      console.error("업체 생성 중 오류 발생:", error);
-      alert("업체 생성에 실패했습니다. 다시 시도해주세요.");
+      console.error("업체 등록 중 오류 발생:", error);
+      alert("업체 등록에 실패했습니다. 다시 시도해주세요.");
     }
   }
 
   return (
     <InputFormLayout
-      title="▹ 업체 생성"
+      title="▹ 업체 등록"
       onSubmit={handleSubmit}
       isLoading={false}
     >

--- a/src/components/pages/adminOrganizationsPage/index.tsx
+++ b/src/components/pages/adminOrganizationsPage/index.tsx
@@ -2,7 +2,14 @@
 
 import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createListCollection, Heading, Stack, Table } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  createListCollection,
+  Heading,
+  Stack,
+  Table,
+} from "@chakra-ui/react";
 import StatusTag from "@/src/components/common/StatusTag";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
@@ -76,6 +83,11 @@ function AdminOrganizationsPageContent() {
     params: [keyword, type, status, currentPage, pageSize],
   });
 
+  // 신규등록 버튼 클릭 시 - 업체 등록 페이지로 이동
+  const handleMemberCreateButton = () => {
+    router.push("/admin/organizations/create");
+  };
+
   // 페이지 변경 시 새로운 데이터를 가져오는 함수
   const handlePageChange = (page: number) => {
     const params = new URLSearchParams(window.location.search);
@@ -95,18 +107,27 @@ function AdminOrganizationsPageContent() {
         <Heading size="2xl" color="gray.600">
           업체 관리
         </Heading>
-        <SearchSection keyword={keyword} placeholder="업체명 입력">
-          <FilterSelectBox
-            statusFramework={organizationTypeFramework}
-            selectedValue={type}
-            queryKey="type"
-          />
-          <FilterSelectBox
-            statusFramework={OrganizationStatusFramework}
-            selectedValue={status}
-            queryKey="status"
-          />
-        </SearchSection>
+        <Box display="flex" justifyContent="space-between">
+          <SearchSection keyword={keyword} placeholder="업체명 입력">
+            <FilterSelectBox
+              statusFramework={organizationTypeFramework}
+              selectedValue={type}
+              queryKey="type"
+            />
+            <FilterSelectBox
+              statusFramework={OrganizationStatusFramework}
+              selectedValue={status}
+              queryKey="status"
+            />
+          </SearchSection>
+          <Button
+            variant={"surface"}
+            _hover={{ backgroundColor: "#00a8ff", color: "white" }}
+            onClick={handleMemberCreateButton}
+          >
+            신규 등록
+          </Button>
+        </Box>
         <CommonTable
           headerTitle={
             <Table.Row

--- a/src/constants/defaultValues.ts
+++ b/src/constants/defaultValues.ts
@@ -16,14 +16,14 @@ export const defaultValuesOfLogin = {
 
 // 초기 입력값 세팅
 export const defaultValuesOfMember = {
-  organizationId: "123e4567-e89b-12d3-a456-426614174000",
-  name: "",
+  organizationId: "1",
+  name: "주농퐉",
   role: "MEMBER", // radio 버튼
-  email: "",
-  password: "https://", // <input> url 타입 기본 속성은 https:// 를 입력해야 돼서 초기값으로 세팅
-  phoneNum: "",
-  jobRole: "",
-  jobTitle: "",
-  introduction: "",
-  remark: "",
+  email: "user@example.com",
+  password: "password1!", // <input> url 타입 기본 속성은 https:// 를 입력해야 돼서 초기값으로 세팅
+  phoneNum: "010-9081-6109",
+  jobRole: "개발자",
+  jobTitle: "팀장",
+  introduction: "안녕하세요. 주농퐉입니다.",
+  remark: "특이사항 없습니다.",
 };

--- a/src/constants/validationRules.ts
+++ b/src/constants/validationRules.ts
@@ -49,8 +49,12 @@ export const validationRulesOfLogin = {
 export const validationRulesOfCreatingMember = {
   organizationId: {
     isValid: (value: string) => value.trim() !== "", // trim(): value에서 공백이 모두 제거된 값을 반환
-    errorMessage: "업체명을 입력하세요.",
+    errorMessage: "업체ID를 입력하세요.",
   },
+  // organizationId: {
+  //   isValid: (value: string) => typeof value !== "number", // trim(): value에서 공백이 모두 제거된 값을 반환
+  //   errorMessage: "업체ID를 입력하세요.",
+  // },
   name: {
     isValid: (value: string) => value.trim() !== "",
     errorMessage: "회원 성함을 입력하세요.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ export interface PaginationProps {
 // 회원 타입
 export interface MemberProps {
   id: string; // 회원 ID
-  organizationId: string; // 소속 업체 ID
+  organizationId: number; // 소속 업체 ID
   organizationName: string; // 소속 업체 이름
   role: "ADMIN" | "MEMBER"; // 역할 (Enum)
   status: "ACTIVE" | "INACTIVE"; // 상태 (Enum)
@@ -36,6 +36,26 @@ export interface MemberProps {
   regAt: string; // 등록일
   introduction: string; // 자기소개
   remark: string; // 비고
+}
+
+// `createMember` 함수에서 입력값의 타입 정의
+export interface CreateMemberInput {
+  role: string;
+  organizationId: number;
+  name: string;
+  email: string;
+  password: string;
+  phoneNum: string;
+  jobRole: string;
+  jobTitle: string;
+  introduction: string;
+  remark: string;
+}
+
+// 반환값의 타입 정의
+export interface CreateMemberResponse {
+  success: boolean;
+  member: MemberProps;
 }
 
 export interface MemberListResponse {
@@ -183,8 +203,6 @@ export interface ContentBlock {
   data: string | { src: string };
 }
 
-
-
 // 게시글
 export interface Article {
   id: number;
@@ -234,7 +252,6 @@ export interface ArticleComment {
   replies: ArticleReply[];
 }
 
-
 // 댓글의 답글
 export interface ArticleReply {
   id: number;
@@ -265,7 +282,7 @@ export interface NoticeProps {
   title: string; // 계약 단계
   content: string; // 시작일시
   category: string; // 시작일시
-  priority: string; // 
+  priority: string; //
   isDeleted: boolean; // 마감일시
   regAt: string; // 고객사 이름
   updatedAt: string; // 개발사 이름
@@ -277,7 +294,7 @@ export interface NoticeListResponse {
 }
 
 export interface ProjectProgressStepProps {
-  id: string,
-  title:string,
-  count: number
+  id: string;
+  title: string;
+  count: number;
 }


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 회원 등록 API 연동
- Related to #89 

### 🔧 What has been changed?

- 회원관리/업체관리 페이지에 '신규 등록' 버튼 UI 재구현
- 회원 등록 API 연동 (업체 ID: string 타입)
- 추후 첨부파일 업로드 시 API 연동 코드 구현 완료 (주석 처리)

### 📸 Screenshots / GIFs (if applicable)

**1) 회원 관리 페이지 - 신규 등록 버튼 UI 재구현**

<img width="935" alt="image" src="https://github.com/user-attachments/assets/374044ce-8873-4be7-a66f-2c42b6aea98b" />

**2) 회원 등록 페이지 - 신규 회원 데이터 입력**

![image](https://github.com/user-attachments/assets/64a563f6-f39b-4d58-a714-747206d7a498)

**3) 회원 등록 페이지 - 등록 완료**

![image](https://github.com/user-attachments/assets/8e3c976c-c2a6-4f0c-b7f0-4dc704ea2ee1)

**4) 회원 등록 API 호출 결과 - 중복된 이메일로 등록 실패**

![image](https://github.com/user-attachments/assets/1e94de0d-928c-4ab8-9919-1a56bc8d62e8)

### ⚠️ Precaution & Known issues

- 추후 첨부파일 업로드 시 API 연동 코드 구현 완료 (주석 처리)

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
