### PR TITLE
회원 상세조회 및 회원 정보 수정 API 연동

### DIFF
--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -4,8 +4,10 @@ import {
   CreateMemberInput,
   CreateMemberResponse,
   MemberListResponse,
+  MemberProps,
 } from "@/src/types";
 
+// 🔹 회원 목록 Fetch API
 export async function fetchMemberList(
   keyword: string = "", // 검색키워드
   role: string = "", // 계정타입
@@ -20,7 +22,7 @@ export async function fetchMemberList(
   return response.data;
 }
 
-// 회원 생성 API (파일 업로드 X)
+// 🔹 회원 생성 API (파일 업로드 X)
 export async function createMember(
   role: string,
   organizationId: string,
@@ -50,7 +52,7 @@ export async function createMember(
   return response.data; // 생성된 데이터 반환
 }
 
-// 회원 생성 API (파일 업로드 O)
+// 🔹 회원 생성 API (파일 업로드 O)
 export async function createMemberWithFile(
   data: CreateMemberInput,
   file: any,
@@ -77,4 +79,39 @@ export async function createMemberWithFile(
   console.log("회원 등록 API 호출 응답 - response: ", response);
   console.log("회원 등록 API 호출 응답 - response.data: ", response.data);
   return response.data; // 생성된 데이터 반환
+}
+
+// 🔹 회원 상세 정보 가져오기
+export async function fetchMemberDetails(
+  memberId: string,
+): Promise<MemberProps> {
+  console.log("회원 상세정보 가져오기 API 호출 전");
+  const response = await axiosInstance.get(`/admins/members/${memberId}`);
+  console.log("회원 상세정보 가져오기 API 호출 후 - response: ", response);
+  console.log(
+    "회원 상세정보 가져오기 API 호출 후 - response.data: ",
+    response.data,
+  );
+  return response.data.data; // ✅ `data` 필드만 반환하도록 수정
+}
+
+// 🔹 회원 정보 수정 (PATCH 요청)
+export async function updateMember(
+  memberId: string,
+  updateData: Partial<MemberProps>,
+) {
+  console.log("회원 정보 수정 API 호출 전");
+  const response = await axiosInstance.patch(
+    `/admins/members/${memberId}`,
+    updateData,
+  );
+  console.log("회원 정보 수정 API 호출 후 - response: ", response);
+  console.log("회원 정보 수정 API 호출 후 - response.data: ", response.data);
+
+  return response.data;
+}
+
+// 🔹 회원 삭제
+export async function deleteMember(memberId: string): Promise<void> {
+  await axiosInstance.delete(`/admins/members/delete/${memberId}`);
 }

--- a/src/components/common/InputForm.module.css
+++ b/src/components/common/InputForm.module.css
@@ -1,44 +1,38 @@
-.inputField {
-  width: 100%;
-  margin-bottom: 16px;
-}
-
-.label {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 14px;
-  font-weight: bold;
-  color: #4a5568;
-  text-align: left;
-}
-
-.required {
-  color: red;
-  margin-left: 4px;
-}
-
 .input {
   width: 100%;
   padding: 10px;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
-  outline: none;
-  transition: border-color 0.2s ease;
+  border-radius: 5px;
+  font-size: 16px;
+  transition:
+    background-color 0.3s,
+    border 0.3s;
 }
 
-.input:focus {
-  border-color: #00a8ff;
+.input.disabled {
+  background-color: #f0f0f0;
+  color: #666;
+  cursor: not-allowed;
 }
 
-.error {
-  border-color: red;
+.input.changed {
+  background-color: #e8f5e9 !important; /* ✅ 변경된 입력 필드 연한 초록색 강조 */
+  border: 1px solid #4caf50 !important;
+}
+
+.label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 5px;
+}
+
+.required {
+  color: red;
+  margin-left: 5px;
 }
 
 .errorText {
-  display: block;
+  font-size: 12px;
   color: red;
-  font-size: 10px;
-  height: 12px;
-  margin-top: 4px;
+  height: 16px;
 }

--- a/src/components/common/InputForm.tsx
+++ b/src/components/common/InputForm.tsx
@@ -1,5 +1,6 @@
 import { InputFormData } from "@/src/types";
 import styles from "./InputForm.module.css";
+import { useEffect, useState } from "react";
 
 // 공통 컴포넌트 (로그인/회원 생성/업체 생성 등 입력창 & 에러메시지)
 export default function InputForm({
@@ -10,20 +11,39 @@ export default function InputForm({
   value = "",
   error = "",
   onChange,
+  disabled = false, // ✅ 기본값 false 추가
 }: InputFormData) {
+  const [originalValue, setOriginalValue] = useState(value); // ✅ 초기값 저장
+  const [isChanged, setIsChanged] = useState(false); // ✅ 변경 여부 상태 관리
+
+  useEffect(() => {
+    // 🔹 입력값이 변경될 경우 상태 반영
+    setIsChanged(value !== originalValue); // 초기값이 비어있지 않으면 변경된 것으로 간주
+  }, [value, originalValue]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (onChange) {
+      onChange(e);
+    }
+  }
+
   return (
     <div className={styles.inputField}>
       <label htmlFor={id} className={styles.label}>
         {label}
-        <span className={styles.required}>*</span>
+        {/* ✅ disabled일 경우 * 숨김 */}
+        {!disabled && <span className={styles.required}>*</span>}{" "}
       </label>
       <input
         id={id}
-        className={`${styles.input} ${error ? styles.error : ""}`}
+        className={`${styles.input} ${error ? styles.error : ""} ${
+          disabled ? styles.disabled : ""
+        } ${isChanged ? styles.changed : ""}`} // ✅ 변경된 필드 스타일 적용
         type={type}
         placeholder={placeholder}
         value={value}
         onChange={onChange}
+        disabled={disabled} // ✅ 추가: 입력 비활성화 적용
       />
       {/* 에러 메시지가 없는 경우, 화면에는 보이지 않지만 고정된 높이를 유지 */}
       {/* 에러가 없으면 빈 공백 출력 */}

--- a/src/components/layouts/InputFormLayout.module.css
+++ b/src/components/layouts/InputFormLayout.module.css
@@ -1,47 +1,47 @@
-.container {
-  max-width: 800px;
-  width: 100%;
-  margin: auto;
-  padding: 16px;
-  border-radius: 10px;
-}
-
-.formWrapper {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  margin: auto;
-  padding: 16px;
-  background-color: white;
-}
-
-.title {
-  font-size: 18px;
+.pageTitle {
+  font-size: 24px;
   font-weight: bold;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
 }
 
 .submitButton {
   width: 100%;
-  padding: 12px;
-  background-color: #00a8ff;
+  max-width: 400px;
+  background-color: #007bff;
   color: white;
+  padding: 10px 15px;
   border: none;
-  border-radius: 4px;
-  font-weight: bold;
-  transition: background-color 0.3s ease;
   cursor: pointer;
+  font-size: 16px;
+  border-radius: 5px;
+  transition: background-color 0.3s;
 }
 
 .submitButton:hover {
-  background-color: #007acc;
+  background-color: #0056b3;
 }
 
-.submitButton:disabled {
-  background-color: #ccc;
-  cursor: not-allowed;
+.deleteButton {
+  background-color: #dc3545; /* ✅ 삭제 버튼 색상 (빨간색) */
+  color: white;
+  padding: 8px 12px;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 5px;
+  transition: background-color 0.3s;
+  position: absolute;
+  bottom: 10px;
+  right: 10px; /* ✅ 우측 하단 배치 */
 }
 
-.loading {
-  background-color: #ccc;
+.deleteButton:hover {
+  background-color: #c82333;
 }

--- a/src/components/layouts/InputFormLayout.tsx
+++ b/src/components/layouts/InputFormLayout.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { ReactNode } from "react";
+import { usePathname } from "next/navigation"; // ✅ 현재 URL 경로 가져오기
 import styles from "./InputFormLayout.module.css";
 
 export default function InputFormLayout({
@@ -6,29 +9,59 @@ export default function InputFormLayout({
   children,
   onSubmit,
   isLoading,
+  onDelete, // 삭제 핸들러 추가
 }: {
   title: string; // title - 페이지 별 입력 폼 타이틀
   children: ReactNode; // 입력 폼 내부에 렌더링 될 내용
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void; // 입력 폼 제출 핸들러
   isLoading: boolean; // 제출 버튼의 로딩 상태
+  onDelete?: () => void; // 삭제 핸들러 (선택 사항)
 }) {
+  const pathname = usePathname();
+  const isDetailPage = pathname.includes(`/admin/members/`); // ✅ 상세 조회 페이지 여부 확인
+
   return (
     <div className={styles.container}>
       <div className={styles.formWrapper}>
-        <h1 className={styles.title}>{title}</h1>
+        <h1 className={styles.pageTitle}>{title}</h1>
         <form onSubmit={onSubmit}>
-          {/* {children} 로 각 페이지 컴포넌트가 들어옴 */}
           {children}
-          <button
-            type="submit"
-            className={`${styles.submitButton} ${
-              isLoading ? styles.loading : ""
-            }`}
-            disabled={isLoading}
-            aria-busy={isLoading}
-          >
-            {isLoading ? "처리 중..." : "등록하기"}
-          </button>
+          <div className={styles.buttonContainer}>
+            {isDetailPage ? (
+              <>
+                <button
+                  type="submit"
+                  className={`${styles.submitButton} ${
+                    isLoading ? styles.loading : ""
+                  }`}
+                  disabled={isLoading}
+                  aria-busy={isLoading}
+                >
+                  {isLoading ? "처리 중..." : "수정하기"}
+                </button>
+                {onDelete && (
+                  <button
+                    type="button"
+                    className={styles.deleteButton} // ✅ 삭제 버튼 스타일 적용
+                    onClick={onDelete}
+                  >
+                    삭제하기
+                  </button>
+                )}
+              </>
+            ) : (
+              <button
+                type="submit"
+                className={`${styles.submitButton} ${
+                  isLoading ? styles.loading : ""
+                }`}
+                disabled={isLoading}
+                aria-busy={isLoading}
+              >
+                {isLoading ? "처리 중..." : "등록하기"}
+              </button>
+            )}
+          </div>
         </form>
       </div>
     </div>

--- a/src/components/pages/adminMemberPage/components/MemberDetailForm.tsx
+++ b/src/components/pages/adminMemberPage/components/MemberDetailForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { deleteMember, updateMember } from "@/src/api/members";
+import InputForm from "@/src/components/common/InputForm";
+import InputFormLayout from "@/src/components/layouts/InputFormLayout";
+import { Radio, RadioGroup } from "@/src/components/ui/radio";
+import { MemberProps } from "@/src/types";
+import { Box, Flex, HStack } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { validationRulesOfUpdatingMember } from "@/src/constants/validationRules"; // 🔹 유효성 검사 규칙 import
+
+export default function MemberDetailForm({
+  memberData,
+  memberId,
+}: {
+  memberData: MemberProps; // ✅ 회원 상세 타입 추가
+  memberId: string;
+}) {
+  const route = useRouter();
+  const [formData, setFormData] = useState<MemberProps>(memberData); // ✅ useState에 타입 추가
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [errors, setErrors] = useState<{ [key: string]: string | null }>({}); // 🔹 유효성 검사 에러 상태
+
+  // 🔹 입력값 변경 처리 및 유효성 검사 실행
+  function handleChange(field: keyof MemberProps, value: string) {
+    // ✅ field는 MemberProps의 key, value는 string
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+
+    // ✅ 유효성 검사 규칙이 있는 필드만 검사
+    if (field in validationRulesOfUpdatingMember) {
+      const isValid =
+        validationRulesOfUpdatingMember[
+          field as keyof typeof validationRulesOfUpdatingMember
+        ].isValid(value);
+      setErrors((prev) => ({
+        ...prev,
+        [field]: isValid
+          ? null
+          : validationRulesOfUpdatingMember[
+              field as keyof typeof validationRulesOfUpdatingMember
+            ].errorMessage,
+      }));
+    }
+  }
+
+  // 🔹 전체 입력값 유효성 검사 (수정 버튼 활성화 여부 체크)
+  function isFormValid() {
+    return Object.values(errors).every((error) => !error);
+  }
+
+  // 📌 회원 정보 수정
+  async function handleUpdate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    if (!isFormValid()) {
+      alert("입력값을 다시 확인해주세요.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      await updateMember(memberId, {
+        name: formData.name,
+        phoneNum: formData.phoneNum,
+        jobRole: formData.jobRole,
+        jobTitle: formData.jobTitle,
+        introduction: formData.introduction,
+        remark: formData.remark,
+      });
+      alert("회원 정보가 수정되었습니다.");
+    } catch (error) {
+      alert("수정 실패: 다시 시도해주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  // 📌 회원 삭제
+  async function handleDelete() {
+    if (!confirm("정말 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteMember(memberId);
+      alert("회원이 삭제되었습니다.");
+      route.push("/admin/members");
+    } catch (error) {
+      console.error("회원 삭제 중 오류 발생:", error);
+      alert("회원 삭제에 실패했습니다.");
+    }
+  }
+
+  return (
+    <InputFormLayout
+      title="▹ 회원 상세 조회"
+      onSubmit={handleUpdate}
+      isLoading={isSubmitting}
+      onDelete={handleDelete} // ✅ 삭제 핸들러 추가
+    >
+      {/* ✅ 수정 불가 필드 */}
+      <InputForm
+        id="email"
+        type="email"
+        label="로그인 Email"
+        value={formData.email}
+        disabled
+      />
+      <InputForm
+        id="role"
+        type="text"
+        label="사용자 권한"
+        value={formData.role}
+        disabled
+      />
+      {/* ✅ 수정 가능 필드 */}
+      <InputForm
+        id="name"
+        type="text"
+        label="성함"
+        value={formData.name}
+        onChange={(e) => handleChange("name", e.target.value)}
+        error={errors.name ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+      <InputForm
+        id="phoneNum"
+        type="tel"
+        label="연락처"
+        value={formData.phoneNum}
+        onChange={(e) => handleChange("phoneNum", e.target.value)}
+        error={errors.phoneNum ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+      <InputForm
+        id="jobRole"
+        type="text"
+        label="직무"
+        value={formData.jobRole}
+        onChange={(e) => handleChange("jobRole", e.target.value)}
+        error={errors.jobRole ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+      <InputForm
+        id="jobTitle"
+        type="text"
+        label="직함"
+        value={formData.jobTitle}
+        onChange={(e) => handleChange("jobTitle", e.target.value)}
+        error={errors.jobTitle ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+      <InputForm
+        id="introduction"
+        type="text"
+        label="회원 소개"
+        value={formData.introduction}
+        onChange={(e) => handleChange("introduction", e.target.value)}
+        error={errors.introduction ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+      <InputForm
+        id="remark"
+        type="text"
+        label="특이사항"
+        value={formData.remark}
+        onChange={(e) => handleChange("remark", e.target.value)}
+        error={errors.remark ?? undefined} // 🔹 null 값을 undefined로 변환
+      />
+    </InputFormLayout>
+  );
+}

--- a/src/components/pages/adminMemberPage/index.tsx
+++ b/src/components/pages/adminMemberPage/index.tsx
@@ -1,3 +1,58 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import MemberDetailForm from "@/src/components/pages/adminMemberPage/components/MemberDetailForm";
+import { fetchMemberDetails } from "@/src/api/members";
+import { MemberProps } from "@/src/types";
+
 export default function AdminMemberPage() {
-  return <div>회원 상세페이지</div>;
+  const router = useRouter();
+  const params = useParams();
+  // URL에서 memberId 가져오기
+  // memberId를 string으로 변환하여 사용.
+  const memberId = String(
+    Array.isArray(params.memberId) ? params.memberId[0] : params.memberId,
+  ); // ✅ memberId를 string으로 변환
+  // 초기 상태를 null로 설정하되, MemberProps | null 타입을 명시하여 타입 호환 문제 해결.
+  const [memberData, setMemberData] = useState<MemberProps | null>(null);
+
+  // 🔹 memberId가 없는 경우, 404 페이지로 리다이렉트
+  useEffect(() => {
+    if (!memberId) {
+      router.replace("/404");
+    }
+  }, [memberId, router]);
+
+  // 🔹 회원 상세 데이터 가져오기
+  useEffect(() => {
+    const getMember = async () => {
+      if (!memberId) return; // memberId가 없는 경우 API 호출 방지
+
+      try {
+        console.log("Fetching member data for ID:", memberId);
+        const response = await fetchMemberDetails(memberId);
+        console.log("회원 데이터 fetch 결과:", response);
+
+        if (!response) {
+          router.replace("/404"); // 🚀 데이터가 없는 경우 404 이동
+          return;
+        }
+
+        setMemberData(response); // ✅ 정확한 `data` 값 저장
+      } catch (error) {
+        console.error("회원 데이터 조회 실패:", error);
+        router.replace("/404");
+      }
+    };
+    getMember(); // ✅ 함수 실행
+  }, [memberId]);
+
+  if (!memberData) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <MemberDetailForm memberData={memberData} memberId={memberId as string} />
+  );
 }

--- a/src/components/pages/adminMembersPage/index.tsx
+++ b/src/components/pages/adminMembersPage/index.tsx
@@ -99,7 +99,7 @@ function AdminMembersPageContent() {
   };
 
   const handleRowClick = (id: string) => {
-    router.push(`/admins/members/${id}`);
+    router.push(`/admin/members/${id}`);
   };
 
   return (

--- a/src/constants/validationRules.ts
+++ b/src/constants/validationRules.ts
@@ -94,3 +94,47 @@ export const validationRulesOfCreatingMember = {
     errorMessage: "회원 특이사항을 입력하세요.",
   },
 };
+
+// validationRulesOfUpdatingMember의 키를 MemberProps 전체가 아니라 유효성 검사가 필요한 필드만 따로 명시함
+
+const updatableFields = [
+  "phoneNum",
+  "name",
+  "jobRole",
+  "jobTitle",
+  "introduction",
+  "remark",
+] as const;
+
+export const validationRulesOfUpdatingMember: Record<
+  (typeof updatableFields)[number], // ✅ 특정 필드만 타입으로 지정
+  {
+    isValid: (value: string) => boolean;
+    errorMessage: string;
+  }
+> = {
+  phoneNum: {
+    isValid: (value: string) => /^\d{3}-\d{3,4}-\d{4}$/.test(value), // 전화번호 형식 체크
+    errorMessage: "유효한 전화번호 형식이 아닙니다. (예: 010-1234-5678)",
+  },
+  name: {
+    isValid: (value: string) => value.length > 1,
+    errorMessage: "이름은 최소 2자 이상 입력해야 합니다.",
+  },
+  jobRole: {
+    isValid: (value: string) => value.length > 0,
+    errorMessage: "직무를 입력해주세요.",
+  },
+  jobTitle: {
+    isValid: (value: string) => value.length > 0,
+    errorMessage: "직함을 입력해주세요.",
+  },
+  introduction: {
+    isValid: (value: string) => value.length > 0,
+    errorMessage: "회원 소개를 입력해주세요.",
+  },
+  remark: {
+    isValid: (value: string) => value.length < 200,
+    errorMessage: "특이사항은 최대 200자까지 입력 가능합니다.",
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ export interface PaginationProps {
 // 회원 타입
 export interface MemberProps {
   id: string; // 회원 ID
-  organizationId: number; // 소속 업체 ID
+  organizationId: string; // 소속 업체 ID
   organizationName: string; // 소속 업체 이름
   role: "ADMIN" | "MEMBER"; // 역할 (Enum)
   status: "ACTIVE" | "INACTIVE"; // 상태 (Enum)
@@ -268,11 +268,12 @@ export interface InputFormData {
   label: string;
   id: string;
   type: "text" | "email" | "password" | "number" | "tel" | "url"; // 가능한 타입만 명시;
-  placeholder: string;
+  placeholder?: string;
   value?: string;
   error?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean; // ✅ 추가: 입력 비활성화 속성
 }
 
 // 공지사항


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 회원 상세조회 및 회원 정보 수정 API 연동
- Related to #91 

### 🔧 What has been changed?

1) 회원 상세조회 및 수정 페이지 화면 UI 구현
2) 회원 상세조회 API 연동
3) 회원 정보 수정 API 연동
4) 공통 컴포넌트(style 파일 포함) 코드 보완

### 📸 Screenshots / GIFs (if applicable)

**1) 회원 상세조회 및 수정 페이지 화면 UI 구현**

![image](https://github.com/user-attachments/assets/644cc813-f8be-4ac1-bb3b-d77201e61592)

2) 회원 상세조회 API 연동

![image](https://github.com/user-attachments/assets/d3914513-946b-496c-ab30-c00bb07af164)

3) 회원 정보 수정 API 연동

<img width="962" alt="image" src="https://github.com/user-attachments/assets/012396eb-2102-4059-9a97-d66676a90db2" />

### ⚠️ Precaution & Known issues

`adminMemberPage` 폴더의 페이지 파일과 `InputForm.tsx`, `InputFormLayout.tsx` 등 공통 컴포넌트 파일, `member.ts` API 파일을 중점적으로 확인해주시면 감사하겠습니다.

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
