### PR TITLE
업체 생성 시 파일 업로드 API 연동

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -38,7 +38,7 @@ export async function fetchOrganizationDetails(
 // 📌 업체 생성 API (파일 업로드 API 완성 시 추가 구현 예정)
 export async function createOrganization(
   data: CreateOrganizationInput,
-  file: any, // file 타입을 File 또는 null로 처리
+  file?: any,
 ): Promise<CommonResponseType<CreateOrganizationResponse>> {
   const formData = new FormData();
   // content 객체를 JSON 문자열로 변환하여 추가

--- a/src/components/common/InputForm.module.css
+++ b/src/components/common/InputForm.module.css
@@ -1,5 +1,22 @@
-.input {
+/* 입력 필드 컨테이너 */
+.inputFieldContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ✅ 파일 첨부 버튼과 선택된 파일명을 한 줄로 배치 */
+.fileUploadContainer {
+  display: flex;
+  align-items: center;
   width: 100%;
+  gap: 12px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.input {
+  flex: 1; /* 🔹 너비 자동 조절 */
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 5px;
@@ -35,4 +52,35 @@
   font-size: 12px;
   color: red;
   height: 16px;
+}
+
+/* ✅ 숨겨진 파일 선택 input */
+.fileInputHidden {
+  display: none;
+}
+
+/* ✅ 파일 업로드 버튼 */
+.fileUploadButton {
+  background-color: #007bff;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.3s;
+  white-space: nowrap; /* 🔹 줄 바꿈 방지 */
+}
+
+.fileUploadButton:hover {
+  background-color: #0056b3;
+}
+
+/* ✅ 선택된 파일명 스타일 */
+.selectedFileName {
+  font-size: 14px;
+  color: #555;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
 }

--- a/src/components/common/InputForm.tsx
+++ b/src/components/common/InputForm.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { InputFormData } from "@/src/types";
-import styles from "./InputForm.module.css";
 import { useEffect, useState } from "react";
+import { InputFormData } from "@/src/types";
+import styles from "@/src/components/common/InputForm.module.css";
 
 // 공통 컴포넌트 (로그인/회원 생성/업체 생성 등 입력창 & 에러메시지)
 export default function InputForm({
@@ -17,6 +17,7 @@ export default function InputForm({
 }: InputFormData) {
   const [originalValue, setOriginalValue] = useState(value); // 초기값 저장
   const [isChanged, setIsChanged] = useState(false); // 변경 여부 상태 관리
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   useEffect(() => {
     // 수정 시 기존 데이터에서 변경된 사항이 있는 경우
@@ -29,24 +30,53 @@ export default function InputForm({
     }
   }
 
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      if (onChange) onChange(e); // 기존 onChange 핸들러 호출
+    }
+  }
+
   return (
-    <div className={styles.inputField}>
+    <div className={styles.inputFieldContainer}>
       <label htmlFor={id} className={styles.label}>
         {label}
-        {!disabled && <span className={styles.required}>*</span>}{" "}
+        {!disabled && <span className={styles.required}>*</span>}
       </label>
-      <input
-        id={id}
-        className={`${styles.input} ${error ? styles.error : ""} ${
-          disabled ? styles.disabled : "" // 수정 시 입력 불가 처리
-        } ${isChanged ? styles.changed : ""}`} // 수정된 필드 추가 스타일 적용
-        type={type}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-      />
-      {/* 에러 메시지가 없는 경우, 화면에는 보이지 않지만 고정된 높이를 유지 */}
+      {/* ✅ 일반 입력 필드 vs 파일 업로드 필드 분기 */}
+      {type === "file" ? (
+        <div className={styles.fileUploadContainer}>
+          {/* ✅ 파일 첨부 버튼 */}
+          <input
+            type="file"
+            id={id}
+            className={styles.fileInputHidden}
+            onChange={handleFileChange}
+          />
+          <label htmlFor={id} className={styles.fileUploadButton}>
+            파일 첨부
+          </label>
+          {selectedFile && (
+            <span className={styles.selectedFileName}>
+              ✔ {selectedFile.name}
+            </span>
+          )}
+        </div>
+      ) : (
+        <input
+          id={id}
+          className={`${styles.input} ${error ? styles.error : ""} ${
+            disabled ? styles.disabled : "" // 수정 시 입력 불가 처리
+          } ${isChanged ? styles.changed : ""}`} // 수정된 필드 추가 스타일 적용
+          type={type}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      )}
+      {/* 에러 메시지 표시 (에러 메시지가 없는 경우에도 레이아웃 유지 위해 높이를 고정) */}
       <span className={styles.errorText}>{error || " "}</span>{" "}
     </div>
   );

--- a/src/components/layouts/InputFormLayout.tsx
+++ b/src/components/layouts/InputFormLayout.tsx
@@ -16,6 +16,13 @@ import {
 } from "@/src/components/ui/dialog"; // Chakra UI Dialog
 import { Button, Input, Text } from "@chakra-ui/react";
 import styles from "@/src/components/layouts/InputFormLayout.module.css";
+import FileAddSection from "@/src/components/common/FileAddSection";
+interface UploadedFilesProps {
+  originalName: string;
+  saveName: string;
+  url: string;
+  size: number;
+}
 
 export default function InputFormLayout({
   title,
@@ -32,6 +39,7 @@ export default function InputFormLayout({
   onDelete?: (reason: string) => void; // 삭제 핸들러 (탈퇴 사유 전달)
   deleteEntityType?: "회원" | "업체" | "프로젝트"; // 삭제 대상 지정
 }) {
+  const [deleteReason, setDeleteReason] = useState<string>(""); // 삭제 사유 입력 상태
   const urlPathName = usePathname();
   const urlPathSegments = urlPathName.split("/");
   const urlLastPathSegment = urlPathSegments[urlPathSegments.length - 1]; // 생성 페이지와 상세조회 페이지 구분에 쓰일 변수
@@ -41,20 +49,22 @@ export default function InputFormLayout({
       urlPathName.includes(`/admin/organizations/`) ||
       urlPathName.includes("/admin/projects/")) &&
     !isCreatePage; // create가 아닌 경우만 상세 페이지로 처리
-  const [deleteReason, setDeleteReason] = useState<string>(""); // 삭제 사유 입력 상태
+
   const entityType = deleteEntityType || "항목"; // deleteEntityType이 undefined일 경우 삭제 버튼이 생성되지 않아서 기본값을 설정
 
   return (
     <div className={styles.container}>
       <div className={styles.formWrapper}>
-        {/* 페이지 타이틀 */}
+        {/* 📌 페이지 타이틀 */}
         <h1 className={styles.pageTitle}>{title}</h1>
         <form onSubmit={onSubmit}>
+          {/* 📌 페이지 입력폼 */}
           {children}
+          {/* 📌 페이지 하단 - 등록/수정/삭제 버튼 */}
           <div className={styles.buttonContainer}>
             {isDetailPage ? (
               <>
-                {/* 📌 수정 버튼 */}
+                {/* 수정 버튼 */}
                 <button
                   type="submit"
                   className={`${styles.submitButton} ${
@@ -65,7 +75,7 @@ export default function InputFormLayout({
                 >
                   {isLoading ? "처리 중..." : "수정하기"}
                 </button>
-                {/* 📌 삭제 버튼 - 차크라 UI Dialog 컴포넌트 이용 */}
+                {/* 삭제 버튼 - 차크라 UI Dialog 컴포넌트 이용 */}
                 {onDelete && ( // 삭제 핸들러가 존재하는 경우만 표시
                   <DialogRoot role="alertdialog">
                     <DialogTrigger asChild>
@@ -110,7 +120,7 @@ export default function InputFormLayout({
                 )}
               </>
             ) : (
-              /* ✅ 신규 등록 버튼 */
+              /* 신규 등록 버튼 */
               <button
                 type="submit"
                 className={`${styles.submitButton} ${

--- a/src/components/layouts/InputFormLayout.tsx
+++ b/src/components/layouts/InputFormLayout.tsx
@@ -32,10 +32,15 @@ export default function InputFormLayout({
   onDelete?: (reason: string) => void; // 삭제 핸들러 (탈퇴 사유 전달)
   deleteEntityType?: "회원" | "업체" | "프로젝트"; // 삭제 대상 지정
 }) {
-  const pathname = usePathname();
+  const urlPathName = usePathname();
+  const urlPathSegments = urlPathName.split("/");
+  const urlLastPathSegment = urlPathSegments[urlPathSegments.length - 1]; // 생성 페이지와 상세조회 페이지 구분에 쓰일 변수
+  const isCreatePage = urlLastPathSegment === "create" ? true : false; // 생성 페이지인지 확인
   const isDetailPage =
-    pathname.includes(`/admin/members/`) ||
-    pathname.includes(`/admin/organizations/`);
+    (urlPathName.includes(`/admin/members/`) ||
+      urlPathName.includes(`/admin/organizations/`) ||
+      urlPathName.includes("/admin/projects/")) &&
+    !isCreatePage; // create가 아닌 경우만 상세 페이지로 처리
   const [deleteReason, setDeleteReason] = useState<string>(""); // 삭제 사유 입력 상태
   const entityType = deleteEntityType || "항목"; // deleteEntityType이 undefined일 경우 삭제 버튼이 생성되지 않아서 기본값을 설정
 

--- a/src/components/pages/adminOrganizationsCreatePage/index.tsx
+++ b/src/components/pages/adminOrganizationsCreatePage/index.tsx
@@ -89,7 +89,6 @@ export default function AdminOrganizationsCreatePage() {
           </RadioGroup>
         </Flex>
       </Box>
-
       {/* 업체 생성 페이지 - 업체 정보 입력*/}
       <InputForm
         id="name"
@@ -100,17 +99,30 @@ export default function AdminOrganizationsCreatePage() {
         error={inputErrors.name}
         onChange={(e) => handleInputChange("name", e.target.value)}
       />
-
-      <InputForm
-        id="brNumber"
-        type="text"
-        label="사업자 등록번호"
-        placeholder="ex) 123-45-67890"
-        value={inputValues.brNumber}
-        error={inputErrors.brNumber}
-        onChange={(e) => handleInputChange("brNumber", e.target.value)}
-      />
-
+      <Flex gap={4} align="center">
+        <Box flex="1">
+          <InputForm
+            id="brNumber"
+            type="text"
+            label="사업자 등록번호"
+            placeholder="ex) 123-45-67890"
+            value={inputValues.brNumber}
+            error={inputErrors.brNumber}
+            onChange={(e) => handleInputChange("brNumber", e.target.value)}
+          />
+        </Box>
+        <Box flex="1">
+          <InputForm
+            id="businessLicense"
+            type="file"
+            label="사업자 등록증 첨부"
+            placeholder=""
+            onChange={(e) =>
+              handleInputChange("businessLicense", e.target.value)
+            }
+          />
+        </Box>
+      </Flex>
       <InputForm
         id="streetAddress"
         type="text"

--- a/src/components/pages/adminOrganizationsCreatePage/index.tsx
+++ b/src/components/pages/adminOrganizationsCreatePage/index.tsx
@@ -32,11 +32,9 @@ export default function AdminOrganizationsCreatePage() {
         type: inputValues.type,
         brNumber: inputValues.brNumber,
         name: inputValues.name,
-        brCertificateUrl: inputValues.brCertificateUrl,
         streetAddress: inputValues.streetAddress,
         detailAddress: inputValues.detailAddress,
         phoneNumber: inputValues.phoneNumber,
-        typeEnum: inputValues.type, // #TODO typeEnum 불필요한 변수
       };
       // 파일 입력 처리 (예: inputValues.file에서 가져오기)
       const file = null; // 파일이 있을 경우에만 처리
@@ -102,6 +100,7 @@ export default function AdminOrganizationsCreatePage() {
         error={inputErrors.name}
         onChange={(e) => handleInputChange("name", e.target.value)}
       />
+
       <InputForm
         id="brNumber"
         type="text"
@@ -111,15 +110,7 @@ export default function AdminOrganizationsCreatePage() {
         error={inputErrors.brNumber}
         onChange={(e) => handleInputChange("brNumber", e.target.value)}
       />
-      <InputForm
-        id="brCertificateUrl"
-        type="text"
-        label="회사 URL"
-        placeholder="ex) https://www.example.com"
-        value={inputValues.brCertificateUrl}
-        error={inputErrors.brCertificateUrl}
-        onChange={(e) => handleInputChange("brCertificateUrl", e.target.value)}
-      />
+
       <InputForm
         id="streetAddress"
         type="text"

--- a/src/components/pages/adminOrganizationsCreatePage/index.tsx
+++ b/src/components/pages/adminOrganizationsCreatePage/index.tsx
@@ -9,18 +9,28 @@ import InputFormLayout from "@/src/components/layouts/InputFormLayout";
 import { defaultValuesOfOrganizaion } from "@/src/constants/defaultValues";
 import { validationRulesOfCreatingOrganization } from "@/src/constants/validationRules";
 import { createOrganization } from "@/src/api/organizations";
+import { useState } from "react";
 
 export default function AdminOrganizationsCreatePage() {
   const route = useRouter();
   const { inputValues, inputErrors, handleInputChange, checkAllInputs } =
     useForm(defaultValuesOfOrganizaion, validationRulesOfCreatingOrganization);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   function validateInputs() {
     if (!checkAllInputs()) {
+      console.log("입력값 확인요청");
       alert("입력값을 확인하세요.");
       return false;
     }
     return true;
+  }
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+    }
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -36,10 +46,8 @@ export default function AdminOrganizationsCreatePage() {
         detailAddress: inputValues.detailAddress,
         phoneNumber: inputValues.phoneNumber,
       };
-      // 파일 입력 처리 (예: inputValues.file에서 가져오기)
-      const file = null; // 파일이 있을 경우에만 처리
 
-      const response = await createOrganization(organizationData, file);
+      const response = await createOrganization(organizationData, selectedFile);
       console.log("업체 등록 성공 - response: ", response);
       alert("업체가 성공적으로 등록되었습니다.");
       route.push("/admin/organizations");
@@ -74,13 +82,8 @@ export default function AdminOrganizationsCreatePage() {
             *
           </span>
           <RadioGroup
-            // Type이 string인지 확인
-            value={
-              typeof inputValues.Type === "string"
-                ? inputValues.Type
-                : undefined
-            }
-            onValueChange={(e) => handleInputChange("Type", e.value)}
+            value={inputValues.type}
+            onValueChange={(e) => handleInputChange("type", e.value)}
           >
             <HStack gap={6}>
               <Radio value="CUSTOMER">고객사</Radio>
@@ -117,9 +120,7 @@ export default function AdminOrganizationsCreatePage() {
             type="file"
             label="사업자 등록증 첨부"
             placeholder=""
-            onChange={(e) =>
-              handleInputChange("businessLicense", e.target.value)
-            }
+            onChange={(e) => handleFileChange(e)}
           />
         </Box>
       </Flex>

--- a/src/constants/defaultValues.ts
+++ b/src/constants/defaultValues.ts
@@ -1,11 +1,10 @@
 // 업체 생성 페이지 - 입력 폼 초기값 설정
 export const defaultValuesOfOrganizaion = {
-  name: "비엔시스템",
-  brNumber: "123-45-67890",
-  brCertificateUrl: "https://www.naver.com",
-  streetAddress: "서울시 강남구",
-  detailAddress: "역삼동",
-  phoneNumber: "010-9081-6109",
+  name: "",
+  brNumber: "",
+  streetAddress: "",
+  detailAddress: "",
+  phoneNumber: "",
   type: "CUSTOMER",
 };
 

--- a/src/constants/validationRules.ts
+++ b/src/constants/validationRules.ts
@@ -8,10 +8,6 @@ export const validationRulesOfCreatingOrganization = {
     isValid: (value: string) => /^\d{3}-\d{2}-\d{5}$/.test(value),
     errorMessage: "올바른 사업자 등록번호를 입력하세요.",
   },
-  brCertificateUrl: {
-    isValid: (value: string) => /^https?:\/\/.+\..+$/.test(value),
-    errorMessage: "올바른 회사 URL을 입력하세요.",
-  },
   streetAddress: {
     isValid: (value: string) => value.trim() !== "",
     errorMessage: "사업장 도로명 주소를 입력하세요.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,11 +96,10 @@ export interface CreateOrganizationInput {
   type: string;
   brNumber: string;
   name: string;
-  brCertificateUrl: string;
   streetAddress: string;
   detailAddress: string;
   phoneNumber: string;
-  typeEnum: string;
+  // typeEnum: string;
 }
 
 // 반환값의 타입 정의

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -287,7 +287,7 @@ export interface ArticleReply {
 export interface InputFormData {
   label: string;
   id: string;
-  type: "text" | "email" | "password" | "number" | "tel" | "url"; // 가능한 타입만 명시;
+  type: "text" | "email" | "password" | "number" | "tel" | "url" | "file"; // 가능한 타입만 명시;
   placeholder?: string;
   value?: string;
   error?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,7 +99,6 @@ export interface CreateOrganizationInput {
   streetAddress: string;
   detailAddress: string;
   phoneNumber: string;
-  // typeEnum: string;
 }
 
 // 반환값의 타입 정의


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 업체 생성 시 파일 업로드 API 연동
- Related to #98 

### 🔧 What has been changed?


1. 생성 페이지에 수정하기 버튼이 출력되는 부분 수정 - `InputFormLayout.tsx` 
- URL 경로 세분화
- 세분화 된 URL 경로에 'create' 가 포함된 경우와 아닌 경우 2가지로 구분
- 'create' 가 포함된 경우 등록하기 버튼 출력 (반대의 경우, 수정/삭제 버튼 출력)

2. 업로드 생성 페이지에서 brCertificateUrl 입력 필드 삭제 (커뮤니케이션 미스)

3. 파일 업로드 화면 UI 구현

4. 파일 업로드 API 연동

5. API 연동 테스트 (첨부 파일명 - brCertificateUrl 에 string 타입으로 저장됨)
- 첨부 파일: 코드 해석 및 코드 리뷰.pdf
- 서버 저장 데이터: 1738321176465_코드 해석 및 코드 리뷰.pdf|https://flowsync-backend-media-storage.s3.ap-northeast-2.amazonaws.com/1738321176465_코드 해석 및 코드 리뷰.pdf

### 📸 Screenshots / GIFs (if applicable)

![image](https://github.com/user-attachments/assets/b75004bc-dd8d-4f72-b2ce-ea5803de8d60)
![image](https://github.com/user-attachments/assets/5e16ecc0-097d-43ed-a33d-17187689a53b)

### ⚠️ Precaution & Known issues

코드 리뷰 시, commit 순서대로 봐주시면 감사하겠습니다.

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
