### PR TITLE
ArticleForm 리팩토링 및 글 등록 후 경로 이동 추가

### DIFF
--- a/src/components/common/ArticleForm.tsx
+++ b/src/components/common/ArticleForm.tsx
@@ -8,7 +8,7 @@ import { Box, Input, Text, Flex, Button } from "@chakra-ui/react";
 import FileAddSection from "@/src/components/common/FileAddSection";
 import LinkAddSection from "@/src/components/common/LinkAddSection";
 import { uploadFileApi } from "@/src/api/RegisterArticle";
-import { QuestionRequestData } from "@/src/types";
+import { BaseArticleRequestData } from "@/src/types";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -24,21 +24,19 @@ interface LinkListProps {
   url: string;
 }
 
-interface ArticleFormProps {
+interface ArticleFormProps<T extends BaseArticleRequestData> {
   title: string;
   setTitle: (value: string) => void;
-  progressStepId: number;
-  handleSave: (data: QuestionRequestData) => void;
+  handleSave: (data: T) => void;
   children?: React.ReactNode;
 }
 
 export default function ArticleForm({
   title,
   setTitle,
-  progressStepId,
   handleSave,
   children,
-}: ArticleFormProps) {
+}: ArticleFormProps<BaseArticleRequestData>) {
   const editorRef = useRef<EditorJS | null>(null);
   const [linkList, setLinkList] = useState<LinkListProps[]>([]);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFilesProps[]>([]);
@@ -107,15 +105,12 @@ export default function ArticleForm({
           return;
         }
 
-        const requestData: QuestionRequestData = {
+        handleSave({
           title: title,
           content: content, // TODO 이거 백엔드 수정해야 함. 1/28
           linkList: linkList,
           fileInfoList: uploadedFiles,
-          progressStepId: progressStepId,
-        };
-
-        handleSave(requestData);
+        });
 
         alert("저장이 완료되었습니다.");
       } catch (error) {

--- a/src/components/pages/QuestionRegisterPage/index.tsx
+++ b/src/components/pages/QuestionRegisterPage/index.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import { useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import ArticleForm from "@/src/components/common/ArticleForm";
@@ -22,14 +22,20 @@ const progressData = [
 
 export default function QuestionRegisterPage() {
   const { projectId } = useParams();
-  const [progressStepId, setProgressStepId] = useState<number>(1);
+  const router = useRouter();
   const [title, setTitle] = useState<string>("");
+  const [progressStepId, setProgressStepId] = useState<number>(1);
 
-  const handleSave = async (requestData: QuestionRequestData) => {
+  const handleSave = async <T extends QuestionRequestData>(requestData: T) => {
     try {
-      const response = await createQuestionApi(Number(projectId), requestData);
-      console.log("저장 성공", response.data);
+      const response = await createQuestionApi(Number(projectId), {
+        ...requestData,
+        ...(requestData.progressStepId !== undefined
+          ? { progressStepId: requestData.progressStepId }
+          : {}),
+      });
       alert("저장이 완료되었습니다.");
+      router.push(`/projects/${projectId}/questions`);
     } catch (error) {
       console.error("저장 실패:", error);
       alert("저장 중 문제가 발생했습니다.");
@@ -49,12 +55,7 @@ export default function QuestionRegisterPage() {
     >
       <BackButton />
 
-      <ArticleForm
-        title={title}
-        setTitle={setTitle}
-        progressStepId={progressStepId}
-        handleSave={handleSave}
-      >
+      <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
         <ProgressStepAddSection
           progressStepId={progressStepId}
           setProgressStepId={setProgressStepId}

--- a/src/components/pages/TaskRegisterPage/index.tsx
+++ b/src/components/pages/TaskRegisterPage/index.tsx
@@ -4,7 +4,7 @@
 // 목데이터 사용
 
 import { useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import ArticleForm from "@/src/components/common/ArticleForm";
@@ -23,14 +23,20 @@ const progressData = [
 
 export default function TaskRegisterPage() {
   const { projectId } = useParams();
+  const router = useRouter();
   const [title, setTitle] = useState<string>("");
   const [progressStepId, setProgressStepId] = useState<number>(1);
 
-  const handleSave = async (requestData: TaskRequestData) => {
+  const handleSave = async <T extends TaskRequestData>(requestData: T) => {
     try {
-      const response = await createTaskApi(Number(projectId), requestData);
-      console.log("저장 성공", response.data);
+      const response = await createTaskApi(Number(projectId), {
+        ...requestData,
+        ...(requestData.progressStepId !== undefined
+          ? { progressStepId: requestData.progressStepId }
+          : {}),
+      });
       alert("저장이 완료되었습니다.");
+      router.push(`/projects/${projectId}/tasks`);
     } catch (error) {
       console.error("저장 실패:", error);
       alert("저장 중 문제가 발생했습니다.");
@@ -50,12 +56,7 @@ export default function TaskRegisterPage() {
     >
       <BackButton />
 
-      <ArticleForm
-        title={title}
-        setTitle={setTitle}
-        progressStepId={progressStepId}
-        handleSave={handleSave}
-      >
+      <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
         <ProgressStepAddSection
           progressStepId={progressStepId}
           setProgressStepId={setProgressStepId}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -333,18 +333,17 @@ export interface UserInfoResponse {
   remark: string;
 }
 
-export interface QuestionRequestData {
+export interface BaseArticleRequestData {
   title: string;
   content: { type: string; data: string | { src: string } }[];
   linkList: { name: string; url: string }[];
   fileInfoList: { originalName: string; saveName: string; url: string; size: number }[];
-  progressStepId: number;
 }
 
-export interface TaskRequestData {
-  title: string;
-  content: { type: string; data: string | { src: string } }[];
-  linkList: { name: string; url: string }[];
-  fileInfoList: { originalName: string; saveName: string; url: string; size: number }[];
-  progressStepId: number;
+export interface QuestionRequestData extends BaseArticleRequestData {
+  progressStepId?: number;
+}
+
+export interface TaskRequestData extends BaseArticleRequestData {
+  progressStepId?: number;
 }


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : ArticleForm 리팩토링 및 글 등록 후 경로 이동 추가
- Related to #79

### 🔧 What has been changed?

- ArticleForm progressStepId 의존성 제거
- 글 작성 폼 제출 성공후 목록으로 이동 기능 추가

### 📸 Screenshots / GIFs (if applicable)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
