### PR TITLE
헤더 레이아웃 변경 및 로그인 사용자 프로필 조회 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7562,7 +7562,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
       "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,8 +1,14 @@
 import axiosInstance from "@/src/api/axiosInstance";
-import { CommonResponseType, ReissueResponse, UserInfoResponse } from "@/src/types";
+import {
+  CommonResponseType,
+  ReissueResponse,
+  UserInfoResponse,
+} from "@/src/types";
 
 // 사용자 권한 API 호출
-export async function fetchUserInfo(accessToken?: string): Promise<CommonResponseType<UserInfoResponse>> {
+export async function fetchUserInfo(
+  accessToken?: string,
+): Promise<CommonResponseType<UserInfoResponse>> {
   const response = await axiosInstance.get("/me", {
     headers: {
       "Content-Type": "application/json",
@@ -11,12 +17,14 @@ export async function fetchUserInfo(accessToken?: string): Promise<CommonRespons
     withCredentials: true, // ✅ 클라이언트 환경에서도 쿠키 포함
     validateStatus: (status) => status < 500, // 🔹 500 이상만 오류로 처리
   });
-  
+
   return response.data;
 }
 
 // 🔹 Refresh Token을 포함하여 토큰 재발급 요청
-export async function fetchReissueToken(refreshToken?: string): Promise<CommonResponseType<ReissueResponse>> {
+export async function fetchReissueToken(
+  refreshToken?: string,
+): Promise<CommonResponseType<ReissueResponse>> {
   const response = await axiosInstance.get("/reissue", {
     headers: {
       "Content-Type": "application/json",
@@ -31,9 +39,19 @@ export async function fetchReissueToken(refreshToken?: string): Promise<CommonRe
 
 // 로그인 API 호출 => 액세스 토큰 & user 정보 반환
 export async function login(email: string, password: string) {
-  const response = await axiosInstance.post("/login", { email, password });
-  // console.log("로그인 API 응답 완료 - response: ", response);
-  return response;
+  try {
+    const response = await axiosInstance.post("/login", { email, password });
+    if (response.data.code === 200 && response.data.result === "SUCCESS") {
+      return response.data; // 성공 응답 반환
+    } else {
+      // 실패 메시지 처리
+      throw new Error(response.data.message || "로그인에 실패하였습니다.");
+    }
+  } catch (error: any) {
+    console.error("API 호출 에러:", error.message || error);
+    alert("로그인에 실패했습니다. 이메일 또는 비밀번호를 다시 확인하세요.");
+    throw error;
+  }
 }
 
 // 로그아웃 API 호출

--- a/src/app/(loggedIn)/layout.tsx
+++ b/src/app/(loggedIn)/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
-import { Box, Container, Flex } from "@chakra-ui/react";
+import { Box, Container, Flex, IconButton, Text } from "@chakra-ui/react";
 import Header from "@/src/components/layouts/Header";
 import Sidebar from "@/src/components/layouts/Sidebar";
 import { SidebarProvider } from "@/src/context/SidebarContext";
@@ -14,24 +14,27 @@ export default function MemberAndAdminDashboardLayout({
   children,
 }: MemberAndAdminDashboardLayoutProps) {
   return (
-    <>
+    <Flex id="root" direction="column" height="100vh">
       <Header />
-      <Container
-        maxWidth={"100%"}
-        display="flex"
-        flexDirection="row"
-        margin={0}
-        padding={0}
-      >
-        <SidebarProvider>
-          <Sidebar />
-        </SidebarProvider>
-        <Flex width="100%" height="100%" align="center" justify="center">
-          <Box maxW="container.xl" width="100%" height="100%" p={10}>
-            {children}
-          </Box>
-        </Flex>
-      </Container>
-    </>
+      <Flex flex="1">
+        {/* <Header /> */}
+        <Container
+          maxWidth={"100%"}
+          display="flex"
+          flexDirection="row"
+          margin={0}
+          padding={0}
+        >
+          <SidebarProvider>
+            <Sidebar />
+          </SidebarProvider>
+          <Flex width="100%" height="100%" align="center" justify="center">
+            <Box maxW="container.xl" width="100%" height="100%" p={10}>
+              {children}
+            </Box>
+          </Flex>
+        </Container>
+      </Flex>
+    </Flex>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,23 +1,64 @@
 /* 글로벌 스타일 */
 :root {
-  --header-height: 64px;
-  --sidebar-width: 270px;
+  --header-height: 60px;
+  --sidebar-width: 250px;
+  --sidebar-width-mobile: 0px; /* 모바일에서 숨김 */
   --login-card-max-width: 500px;
   --login-card-min-width: 320px; /* 최소 너비 설정 */
   --login-card-padding: 1.5rem;
 }
 
-/* 전체 레이아웃 */
-html,
-body {
+/* Reset */
+* {
   margin: 0;
   padding: 0;
-  width: 100%;
-  height: 100%;
   box-sizing: border-box;
+}
+/* 전체 레이아웃 */
+body {
   font-family: "Roboto", sans-serif;
+  background-color: #f8f9fa;
+  margin: 0;
+  padding: 0;
 }
 
+#root {
+  display: flex;
+  height: 100vh;
+}
+
+/* 헤더 스타일 */
+header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: var(--header-height);
+  background-color: white;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  z-index: 10;
+}
+
+header .logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #333;
+}
+
+header .menu {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+header .menu span {
+  font-weight: medium;
+  cursor: pointer;
+  color: #007bff;
+}
 /* 반응형 디자인 */
 @media (max-width: 1024px) {
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,37 @@
+/* 글로벌 스타일 */
+:root {
+  --header-height: 64px;
+  --sidebar-width: 270px;
+  --login-card-max-width: 500px;
+  --login-card-min-width: 320px; /* 최소 너비 설정 */
+  --login-card-padding: 1.5rem;
+}
+
+/* 전체 레이아웃 */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  font-family: "Roboto", sans-serif;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1024px) {
+}
+
+@media (max-width: 768px) {
+  :root {
+    --login-card-max-width: 90%;
+    --login-card-min-width: 280px; /* 모바일 최소 너비 */
+    --login-card-padding: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --login-card-padding: 0.8rem;
+  }
+}

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -16,7 +16,6 @@ export default function LoginLayout({
           justify="center"
           minHeight="100vh"
           backgroundColor="gray.50"
-          padding="3"
           overflow="hidden" // 스크롤 제거
         >
           <Box
@@ -25,7 +24,6 @@ export default function LoginLayout({
             borderRadius="md"
             bg="white"
             boxShadow="lg"
-            padding="1"
           >
             {children}
           </Box>

--- a/src/components/common/InputForm.module.css
+++ b/src/components/common/InputForm.module.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 90%;
 }
 
 /* ✅ 파일 첨부 버튼과 선택된 파일명을 한 줄로 배치 */

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,108 +1,53 @@
-"use client";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Link from "next/link";
-import { Heading, Flex } from "@chakra-ui/react";
-import Profile, { ProfileProps } from "@/src/components/layouts/Profile";
+import { Box, Flex, Image, Spacer } from "@chakra-ui/react";
+import Profile from "@/src/components/layouts/Profile";
 
 export default function Header() {
-  const [user, setUser] = useState<ProfileProps | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  // 사용자 Role 정보 가져오기 (관리자 계정 여부 체크)
-  useEffect(() => {
-    const getUserData = async () => {
-      try {
-        const userData = localStorage.getItem("user");
-        if (!userData) throw new Error("User 정보가 로컬스토리지에 없습니다.");
-
-        const userObject = JSON.parse(userData);
-        if (
-          typeof userObject.id === "number" &&
-          typeof userObject.name === "string" &&
-          typeof userObject.org_name === "string" &&
-          typeof userObject.job_role === "string" &&
-          typeof userObject.profile_image_url === "string"
-        ) {
-          setUser({
-            id: userObject.id,
-            userName: userObject.name,
-            orgName: userObject.org_name,
-            jobRole: userObject.job_role,
-            profile_image_url: userObject.profile_image_url,
-          });
-        } else {
-          throw new Error("User 데이터 형식이 올바르지 않습니다.");
-        }
-      } catch (err: any) {
-        setError(err.message || "An unknown error occurred");
-      }
-    };
-
-    getUserData();
-  }, []);
-
   return (
     <Flex
       as="nav"
       align="center"
       justify="space-between"
-      wrap="wrap"
+      wrap="nowrap" // 콘텐츠 줄바꿈 방지
       padding="1rem"
-      backgroundColor="gray.200"
+      backgroundColor="white"
       boxShadow="md"
+      position="relative"
+      zIndex="10"
+      height="70px" // 헤더 고정 높이
     >
-      <Flex align="center" mr={5} gap={10}>
-        <Link href="/">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            BN SYSTEM
-          </Heading>
-        </Link>
+      {/* 로고와 메뉴를 묶음 */}
+      <Flex align="center" gap="24">
+        {/* 로고 */}
+        <Box>
+          <Link href="/">
+            <Image
+              src="https://bn-system.com/img/LOGO_SVG.svg"
+              alt="BN SYSTEM"
+              height={{ base: "40px", md: "50px" }} // 반응형 크기 조정
+              objectFit="contain"
+            />
+          </Link>
+        </Box>
 
-        <Link href="/notices">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            공지사항
-          </Heading>
-        </Link>
-
-        <Link href="/login">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            로그인
-          </Heading>
-        </Link>
-
-        <Link href="/admin/members">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            회원관리
-          </Heading>
-        </Link>
-
-        <Link href="/admin/organizations">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            업체관리
-          </Heading>
-        </Link>
-
-        <Link href="/projects/1/tasks/new">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            게시글작성
-          </Heading>
-        </Link>
-
-        <Link href="/projects/1/tasks/1/edit">
-          <Heading as="h1" size="lg" letterSpacing={"-.1rem"}>
-            게시글수정
-          </Heading>
-        </Link>
+        {/* 메뉴 */}
+        <Flex as="ul" listStyleType="none" align="center">
+          <li>
+            <Link href="/notices" style={{ fontSize: "1.1rem" }}>
+              공지사항
+            </Link>
+          </li>
+        </Flex>
       </Flex>
-      {/* Avatar */}
-      {user && (
-        <Profile
-          id={user.id}
-          userName={user.userName}
-          orgName={user.orgName}
-          jobRole={user.jobRole}
-          profile_image_url={user.profile_image_url}
-        />
-      )}{" "}
+
+      {/* Spacer를 사용해 프로필을 오른쪽으로 배치 */}
+      <Spacer />
+
+      {/* 프로필 */}
+      <Box>
+        <Profile />
+      </Box>
     </Flex>
   );
 }

--- a/src/components/layouts/Profile.tsx
+++ b/src/components/layouts/Profile.tsx
@@ -1,35 +1,95 @@
-import { Avatar } from "@/src/components/ui/avatar";
-import { Box, HStack, Stack, Text } from "@chakra-ui/react";
-// import { ProfileProps } from "@/src/types/profile";
+"use client";
 
-export interface ProfileProps {
-  id: number;
-  userName: string;
-  orgName?: string;
-  jobRole?: string;
-  profile_image_url?: string;
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { Flex, Text, Box } from "@chakra-ui/react";
+import {
+  MenuContent,
+  MenuItem,
+  MenuRoot,
+  MenuTrigger,
+} from "@/src/components/ui/menu";
+import { Avatar } from "@/src/components/ui/avatar";
+import { ChevronDown } from "lucide-react";
+import { Loading } from "@/src/components/common/Loading";
+import axiosInstance from "@/src/api/axiosInstance";
+import { getRandomProfileImage } from "@/src/utils/getRandomProfileImage";
+
+interface UserProfileData {
+  name: string;
+  organizationName: string;
+  role: string;
 }
 
-export default function Profile({
-  id,
-  userName,
-  orgName = "Unknown",
-  jobRole = "N/A",
-  profile_image_url,
-}: ProfileProps) {
+export default function Profile() {
+  const [userData, setUserData] = useState<UserProfileData | null>(null);
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 사용자 정보 가져오기
+    const fetchUserData = async () => {
+      try {
+        const response = await axiosInstance.get("/me");
+        if (response.data.code === 200 && response.data.result === "SUCCESS") {
+          setUserData({
+            name: response.data.data.name,
+            organizationName: response.data.data.organizationName,
+            role: response.data.data.role,
+          });
+          // 랜덤 프로필 이미지 설정
+          setProfileImageUrl(getRandomProfileImage());
+        }
+      } catch (error: any) {
+        console.error("사용자 데이터를 가져오지 못했습니다.", error);
+      }
+    };
+
+    fetchUserData();
+  }, []);
+
+  if (!userData) {
+    return <Loading />;
+  }
+
   return (
-    <Box>
-      <Stack>
-        <HStack key={id}>
-          <Avatar name={userName} size="lg" src={profile_image_url} />
-          <Stack gap="1" direction="row">
-            <Text fontWeight="medium">{userName}</Text>
-            <Text color="gray.600" textStyle="sm">
-              {orgName} · {jobRole}
-            </Text>
-          </Stack>
-        </HStack>
-      </Stack>
+    <Box
+      display="Flex"
+      alignItems="center"
+      gap={3}
+      paddingX="1rem"
+      backgroundColor="white" // 배경색
+      _hover={{ backgroundColor: "#ebf2faef" }} // 호버 효과
+      borderRadius="md"
+    >
+      {/* Avatar와 사용자 정보 */}
+      <Avatar size="sm" src={profileImageUrl || ""} name={userData.name} />
+      <Flex direction="row" align="flex-start" gap={3}>
+        <Text fontWeight="bold" fontSize="md" color="black">
+          {userData.name}
+        </Text>
+        <Text fontSize="sm" color="gray.500">
+          {userData.organizationName} · {userData.role}
+        </Text>
+        <MenuRoot>
+          <MenuTrigger asChild>
+            <ChevronDown cursor="pointer" />
+          </MenuTrigger>
+          <MenuContent>
+            {/* 드롭다운 메뉴 */}
+            <MenuItem asChild value="마이페이지">
+              <Link href={"/"}>마이페이지</Link>
+            </MenuItem>
+            <MenuItem
+              asChild
+              value="로그아웃"
+              color="fg.error"
+              _hover={{ bg: "bg.error", color: "fg.error" }}
+            >
+              <Link href={"/"}>로그아웃</Link>
+            </MenuItem>
+          </MenuContent>
+        </MenuRoot>
+      </Flex>
     </Box>
   );
 }

--- a/src/components/pages/loginPage/Login.module.css
+++ b/src/components/pages/loginPage/Login.module.css
@@ -1,0 +1,142 @@
+/* 전체 로그인 컨테이너 */
+.loginContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 80vh;
+  position: relative; /* 기준점 설정 (Popover 버튼을 위치시키기 위함) */
+  overflow: hidden; /* 스크롤 방지 */
+  padding: 2rem; /* 여백 제거 */
+  background-color: #f8f9fa;
+}
+
+/* Popover 버튼 */
+.popoverButton {
+  position: fixed; /* 화면 고정 */
+  top: 20px; /* 화면 위에서 20px */
+  right: 20px; /* 화면 오른쪽에서 20px */
+  background-color: #007bff;
+  color: white;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease;
+  z-index: 100; /* 다른 요소보다 위에 출력 */
+}
+
+.popoverButton:hover {
+  background-color: #0056b3;
+}
+
+/* 로그인 헤더 */
+.loginHeader {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.loginHeader span {
+  font-size: 5rem;
+}
+
+.loginTitle {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin: 0;
+}
+
+.loginSubtitle {
+  font-size: 1rem;
+  color: #6c757d;
+  margin-top: 8px;
+}
+
+/* 로그인 카드 (폼 컨테이너) */
+.loginCard {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 450px;
+  padding: 20px;
+  border: 1px solid #e1e4e8;
+  border-radius: 10px;
+  background-color: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin: 0 auto; /* 카드 위치 중앙 */
+}
+
+/* 입력 필드 공통 스타일 */
+.inputFieldContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+/* 입력 필드 스타일 */
+.input {
+  flex: 1;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  font-size: 16px;
+  transition:
+    border 0.3s,
+    background-color 0.3s;
+}
+
+.input:focus {
+  border-color: #007bff;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.2);
+}
+
+.input.error {
+  border-color: #dc3545;
+  background-color: #f8d7da;
+}
+
+/* 에러 메시지 */
+.errorText {
+  font-size: 12px;
+  color: red;
+  height: 16px;
+}
+
+/* 로그인 버튼 스타일 */
+.loginButton {
+  width: 100%;
+  background-color: #007bff;
+  color: white;
+  padding: 12px 20px;
+  border-radius: 5px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.loginButton:hover {
+  background-color: #0056b3;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .loginCard {
+    max-width: 90%;
+    padding: 16px;
+  }
+
+  .inputFieldContainer > div {
+    flex-direction: column; /* 입력 필드와 버튼을 세로로 배치 */
+  }
+
+  .popoverButton {
+    align-self: flex-start; /* 버튼이 입력 필드 아래로 정렬 */
+    width: 100%; /* 버튼 너비를 입력 필드와 동일하게 */
+  }
+}

--- a/src/components/pages/loginPage/index.tsx
+++ b/src/components/pages/loginPage/index.tsx
@@ -1,23 +1,21 @@
 "use client";
 
 import React, { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { PopoverArrow, Text, VStack } from "@chakra-ui/react";
 import {
-  Box,
-  Button,
-  Flex,
-  Heading,
-  HStack,
-  Separator,
-  Span,
-  Text,
-} from "@chakra-ui/react";
+  PopoverBody,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 import { login } from "@/src/api/auth";
 import { useForm } from "@/src/hook/useForm";
 import InputForm from "@/src/components/common/InputForm";
 import { defaultValuesOfLogin } from "@/src/constants/defaultValues";
 import { validationRulesOfLogin } from "@/src/constants/validationRules";
+import styles from "@/src/components/pages/loginPage/Login.module.css";
 
 export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -30,108 +28,115 @@ export default function LoginPage() {
       alert("입력값을 확인하세요.");
       return false;
     }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(inputValues.email)) {
+      alert("유효한 이메일 형식을 입력하세요.");
+      return false;
+    }
+
+    if (inputValues.password.length < 4) {
+      alert("패스워드는 최소 4자 이상이어야 합니다.");
+      return false;
+    }
+
     return true;
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (isLoading) return; // 이미 로딩 중이라면 요청 중단
     if (!validateInputs()) return;
 
-    // console.log("로그인 시도 - ", inputValues);
-
-    if (await login(inputValues.email, inputValues.password)) {
-      console.log("성공적으로 로그인 되었습니다.");
+    try {
+      setIsLoading(true);
+      const response = await login(inputValues.email, inputValues.password);
+      console.log("로그인 성공:", response);
       route.push("/");
+    } catch (error) {
+      console.error("로그인 처리 실패:", error);
+    } finally {
+      setIsLoading(false); // 로딩 상태 해제
     }
   }
 
   return (
-    <Flex
-      direction="column"
-      align="center"
-      justify="center"
-      minH="100vh"
-      padding="1.5"
-      bg="gray.50"
-    >
-      {/* 제목 */}
-      <Flex
-        direction="column"
-        align="center"
-        fontWeight="medium"
-        gap="2.5"
-        marginBottom="8"
-      >
-        <Span fontSize="8xl">📄</Span>
-        <Heading fontSize="4xl" fontWeight="medium">
-          BN SYSTEM
-        </Heading>
-        <Heading
-          fontSize="lg"
-          fontWeight="medium"
-          color="gray.600"
-          textAlign="center"
-        >
-          기업 회원 전용 페이지에 오신 것을 환영합니다!
-        </Heading>
-      </Flex>
+    <>
+      <PopoverRoot>
+        <PopoverTrigger asChild>
+          <button className={styles.popoverButton}>도움말</button>
+        </PopoverTrigger>
+        <PopoverContent css={{ "--popover-bg": "lightblue" }}>
+          <PopoverArrow />
+          <PopoverBody>
+            <PopoverTitle fontWeight="medium">
+              <strong>이용 가이드</strong>
+            </PopoverTitle>
+            <Text fontSize="sm" color="gray.600" whiteSpace="pre-line">
+              {`
+              * 가이드라인: 본 애플리케이션은 B2B 서비스로 관리자가 직접 회원을 등록하며, 전달받은 ID 와 PW 를 입력하여 로그인합니다.              
+              
+              [관리자 계정]
+              - ID: admin@example.com
+              - PW: 1111
 
-      {/* #TODO InputFormLayout 으로 스타일링 코드 별도 분리 */}
-      {/* 로그인 폼 */}
-      <Box
-        display="flex"
-        flexDirection="column"
-        width="90%"
-        maxW="400px"
-        padding="6"
-        border="1px"
-        borderColor="gray.300"
-        borderRadius="md"
-        bg="white"
-        boxShadow="sm"
-      >
-        <form onSubmit={handleSubmit}>
-          <Flex direction="column" align="center" gap="2">
-            <InputForm
-              id="email"
-              type="email"
-              label="Email address"
-              placeholder="이메일을 입력하세요."
-              value={inputValues.email}
-              error={inputErrors.email}
-              onChange={(e) => handleInputChange("email", e.target.value)}
-            />
-            <InputForm
-              id="password"
-              type="password"
-              label="Password"
-              placeholder="패스워드를 입력하세요."
-              value={inputValues.password}
-              error={inputErrors.password}
-              onChange={(e) => handleInputChange("password", e.target.value)}
-            />
-            <Button
-              type="submit"
-              backgroundColor="#00a8ff"
-              color="white"
-              fontSize="lg"
-              fontWeight="medium"
-              width="100%"
-              disabled={isLoading}
-              _hover={{ backgroundColor: "#007acc" }}
-            >
-              로그인
-            </Button>
-          </Flex>
-        </form>
-        <HStack width="100%" gap="4" justify="center">
-          <Text>
-            <Link href="/login/find-password">비밀번호 찾기</Link>
+              [일반사용자(개발사) 계정]
+              - ID: developermember@example.com
+              - PW: 1111
+
+              [일반사용자(고객사) 계정]
+              - ID: customermember@example.com
+              - PW: 1111
+              `}
+            </Text>
+          </PopoverBody>
+        </PopoverContent>
+      </PopoverRoot>
+      <div className={styles.loginContainer}>
+        {/* 제목 */}
+        <div className={styles.loginHeader}>
+          <Text fontSize="5xl" as="span" role="img" aria-label="document">
+            📄
           </Text>
-          <Separator orientation="vertical" height="4" />
-          <Text>아이디 찾기</Text>
-        </HStack>
-      </Box>
-    </Flex>
+          <h1 className={styles.loginTitle}>BN SYSTEM</h1>
+          <p className={styles.loginSubtitle}>
+            기업 회원 전용 페이지에 오신 것을 환영합니다!
+          </p>
+        </div>
+
+        {/* 로그인 폼 */}
+        <div className={styles.loginCard}>
+          <form onSubmit={handleSubmit}>
+            <VStack className={styles.inputFieldContainer}>
+              <InputForm
+                id="email"
+                type="email"
+                label="Email address"
+                placeholder="이메일을 입력하세요."
+                value={inputValues.email}
+                error={inputErrors.email}
+                onChange={(e) => handleInputChange("email", e.target.value)}
+              />
+              <InputForm
+                id="password"
+                type="password"
+                label="Password"
+                placeholder="패스워드를 입력하세요."
+                value={inputValues.password}
+                error={inputErrors.password}
+                onChange={(e) => handleInputChange("password", e.target.value)}
+              />
+              <button
+                type="submit"
+                className={styles.loginButton}
+                disabled={isLoading}
+              >
+                {isLoading ? "로그인 중..." : "로그인"}
+              </button>
+            </VStack>
+          </form>
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,59 @@
+import { Popover as ChakraPopover, Portal } from "@chakra-ui/react"
+import { CloseButton } from "./close-button"
+import * as React from "react"
+
+interface PopoverContentProps extends ChakraPopover.ContentProps {
+  portalled?: boolean
+  portalRef?: React.RefObject<HTMLElement>
+}
+
+export const PopoverContent = React.forwardRef<
+  HTMLDivElement,
+  PopoverContentProps
+>(function PopoverContent(props, ref) {
+  const { portalled = true, portalRef, ...rest } = props
+  return (
+    <Portal disabled={!portalled} container={portalRef}>
+      <ChakraPopover.Positioner>
+        <ChakraPopover.Content ref={ref} {...rest} />
+      </ChakraPopover.Positioner>
+    </Portal>
+  )
+})
+
+export const PopoverArrow = React.forwardRef<
+  HTMLDivElement,
+  ChakraPopover.ArrowProps
+>(function PopoverArrow(props, ref) {
+  return (
+    <ChakraPopover.Arrow {...props} ref={ref}>
+      <ChakraPopover.ArrowTip />
+    </ChakraPopover.Arrow>
+  )
+})
+
+export const PopoverCloseTrigger = React.forwardRef<
+  HTMLButtonElement,
+  ChakraPopover.CloseTriggerProps
+>(function PopoverCloseTrigger(props, ref) {
+  return (
+    <ChakraPopover.CloseTrigger
+      position="absolute"
+      top="1"
+      insetEnd="1"
+      {...props}
+      asChild
+      ref={ref}
+    >
+      <CloseButton size="sm" />
+    </ChakraPopover.CloseTrigger>
+  )
+})
+
+export const PopoverTitle = ChakraPopover.Title
+export const PopoverDescription = ChakraPopover.Description
+export const PopoverFooter = ChakraPopover.Footer
+export const PopoverHeader = ChakraPopover.Header
+export const PopoverRoot = ChakraPopover.Root
+export const PopoverBody = ChakraPopover.Body
+export const PopoverTrigger = ChakraPopover.Trigger

--- a/src/utils/getRandomProfileImage.ts
+++ b/src/utils/getRandomProfileImage.ts
@@ -1,0 +1,15 @@
+// profileImages.ts
+export enum ProfileImages {
+  Image1 = "https://i.namu.wiki/i/g_KWbWLZvwPIarNr2apToYiutsBO8ousgVj3h-McRHmNr-A-6WNS-HDYkZLt6-dEut9KKiJeZSPyUM57FlmLsg.webp",
+  Image2 = "https://i.namu.wiki/i/bYi9xO4BUA13TAW4BazW8vZF8k2Le_SQbmMokvY6Xi-uu6pbDiPvGILLthl2AYYrhc4c8hlTUBY_bivrO-MEwg.webp",
+  Image3 = "https://i.namu.wiki/i/LYjCNMDiqrNNxRd1McVlMYHO9djCRwnAKRgfcadQappLbKxnASR7d7OJGkeJAlHMC37Wp4xiPz0wuq7J8BpYCQ.webp",
+  Image4 = "https://i.namu.wiki/i/s3j02DGmtjpD6z2f5XjzQwTKY6alOhMZe_CKQQzzpB0zr317PLzqDY8luvbzHABudJO8FAH69EqSjEESuT62Og.webp",
+  Image5 = "https://i.namu.wiki/i/gEPVn6l87ysQuz8rs3sqI_ChOZPJuwq3XguGiM7gyuDIHZUBZaU0om03XQ4HalmIFrFNfQaA3ZzQ2WvixU3X8A.webp",
+  Image6 = "https://i.namu.wiki/i/Mmn329Kk-bEN6x8d00tjFF6Q-XUg7yGCCFoMtMF1OC-r3FdyMFPz7yKIkehTu43_ZLLqM3B4iH0Z6kT59Et0NQ.webp",
+}
+
+export function getRandomProfileImage(): string {
+  const images = Object.values(ProfileImages);
+  const randomIndex = Math.floor(Math.random() * images.length);
+  return images[randomIndex];
+}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 헤더 레이아웃 변경 및 로그인 사용자 프로필 조회 API 연동
- Related to #119 

### 🔧 What has been changed?

1. `Header.tsx` 레이아웃 변경
- `BN SYSTEM` 텍스트 -> `logo` 이미지
- 메뉴 목록 삭제 (로그인/회원관리/업체관리/게시글작성 등)
- `Profile` 컴포넌트 추가

2. `Profile.tsx` 로그인 사용자 프로필 조회 API 연동
- `/me` API 를 통해 로그인 사용자 정보 반환(`id`, `name`, `role`, `organizationId`, `organizationName`, `organizationType`)
- 사용자 정보 중에 3가지 (`name`, `role`, `organizationName`)만 가져와서 화면 출력

### 📸 Screenshots / GIFs (if applicable)

<img width="944" alt="image" src="https://github.com/user-attachments/assets/39b282fc-68b4-4fea-9e85-3245914f17dd" />
<img width="944" alt="image" src="https://github.com/user-attachments/assets/8287ba8a-ae48-4711-88ad-fbbbe80fb35b" />

### ⚠️ Precaution & Known issues

<추후 작업 예정>

1. 로그아웃 API 연동
2. 마이페이지 화면 UI 구현 및 API 연동
3. 프로필 이미지 API 연동 (-> 회원 생성 시, 첨부 파일 업로드 기능 구현 이후에 작업 가능)

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
