### PR TITLE
79 공지사항 UI 제작 및 api 연동

### DIFF
--- a/src/api/notices.ts
+++ b/src/api/notices.ts
@@ -1,8 +1,21 @@
-import { CommonResponseType, NoticeListResponse } from "@/src/types";
+import { CommonResponseType, NoticeListResponse, NoticeRequestData } from "@/src/types";
 import axiosInstance from "@/src/api/axiosInstance";
 
 export async function fetchNoticeList(
+  keyword: string = "", // 검색키워드
+  category: string = "", // 활성화여부
+  currentPage: number,
+  pageSize: number,
 ): Promise<CommonResponseType<NoticeListResponse>> {
-  const response = await axiosInstance.get("/notices");
+  const response = await axiosInstance.get("/notices", {
+    params: { keyword, category, currentPage, pageSize },
+  });
+  return response.data;
+}
+export async function createNoticeApi( requestData: NoticeRequestData ) {
+  const response = await axiosInstance.post(
+    `/admins/notices`,
+    requestData,
+  );
   return response.data;
 }

--- a/src/app/(loggedIn)/projects/[projectId]/tasks/[taskId]/page.tsx
+++ b/src/app/(loggedIn)/projects/[projectId]/tasks/[taskId]/page.tsx
@@ -1,7 +1,3 @@
-// import TaskReadPage from "@/src/components/pages/TaskReadPage";
+import TaskReadPage from "@/src/components/pages/TaskReadPage";
 
-export default function Page() {
-  return <div></div>
-  // return <TaskReadPage />;
-}
-
+export default TaskReadPage;

--- a/src/components/common/FormSelectInput.tsx
+++ b/src/components/common/FormSelectInput.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Box, Text } from "@chakra-ui/react";
+
+interface SelectInputProps<T> {
+  label: string;
+  selectedValue: T;
+  setSelectedValue: (value: T) => void;
+  options: {
+    id: string | number;
+    title: string;
+    value?: string;
+    count?: number;
+  }[];
+}
+
+export default function SelectInput<T extends string | number | undefined>({
+  label,
+  selectedValue,
+  setSelectedValue,
+  options,
+}: SelectInputProps<T>) {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedId = e.target.value as T;
+    setSelectedValue(selectedId);
+  };
+
+  return (
+    <Box>
+      <Text>{label}</Text>
+      <select
+        onChange={handleChange}
+        value={selectedValue}
+        style={{
+          width: "100%",
+          padding: "8px",
+          borderRadius: "4px",
+          border: "1px solid #ccc",
+        }}
+      >
+        <option value={""} disabled>
+          {label} 선택
+        </option>
+        {options.map((option) => (
+          <option key={String(option.id)} value={String(option.id)}>
+            {option.title}
+          </option>
+        ))}
+      </select>
+    </Box>
+  );
+}

--- a/src/components/common/ProgressStepAddSection.tsx
+++ b/src/components/common/ProgressStepAddSection.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Box, Text } from "@chakra-ui/react";
+import { ProjectProgressStepProps } from "@/src/types";
 
 interface ProgressStepAddsectionProps {
   progressStepId: number;
   setProgressStepId: (newStep: number) => void;
-  progressData: { id: number; title: string }[];
+  progressData: ProjectProgressStepProps[];
 }
 
 export default function ProgressStepAddSection({

--- a/src/components/common/ProgressStepSection.tsx
+++ b/src/components/common/ProgressStepSection.tsx
@@ -70,7 +70,7 @@ export default function ProgressStepSection({
         <ProgressStepButton
           key={button.id}
           text={button.title}
-          count={button.count} // 서버에서 받아온 개수 표시
+          count={button.count || 0} // 서버에서 받아온 개수 표시
           isSelected={selectedButtonId === button.id} // 선택 상태 전달
           onClick={() => handleStatusChange(button.id)} // 클릭 핸들러 전달
         />

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -24,6 +24,7 @@ export default function SearchSection({
     // URL 업데이트
     const params = new URLSearchParams(window.location.search);
     params.set("keyword", input); // 검색어 추가
+    params.set("currentPage", "1");
     router.push(`?${params.toString()}`);
   };
 

--- a/src/components/pages/QuestionRegisterPage/index.tsx
+++ b/src/components/pages/QuestionRegisterPage/index.tsx
@@ -7,24 +7,37 @@ import { useParams, useRouter } from "next/navigation";
 import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import ArticleForm from "@/src/components/common/ArticleForm";
-import ProgressStepAddSection from "@/src/components/common/ProgressStepAddSection";
 import { createQuestionApi } from "@/src/api/RegisterArticle";
-import { QuestionRequestData } from "@/src/types";
-
-const progressData = [
-  { id: 1, title: "요구사항정의" },
-  { id: 2, title: "화면설계" },
-  { id: 3, title: "디자인" },
-  { id: 4, title: "퍼블리싱" },
-  { id: 5, title: "개발" },
-  { id: 6, title: "검수" },
-];
+import { ProjectProgressStepProps, QuestionRequestData } from "@/src/types";
+import { fetchProjectQuestionProgressStep as fetchProjectQuestionProgressStepApi } from "@/src/api/projects";
+import { useFetchData } from "@/src/hook/useFetchData";
+import FormSelectInput from "../../common/FormSelectInput";
 
 export default function QuestionRegisterPage() {
   const { projectId } = useParams();
   const router = useRouter();
   const [title, setTitle] = useState<string>("");
-  const [progressStepId, setProgressStepId] = useState<number>(1);
+
+  const resolvedProjectId = Array.isArray(projectId)
+    ? projectId[0]
+    : projectId || "";
+
+  // ProgressStep 데이터 패칭
+  const { data: progressStepData } = useFetchData<
+    ProjectProgressStepProps[],
+    [string]
+  >({
+    fetchApi: fetchProjectQuestionProgressStepApi,
+    params: [resolvedProjectId],
+  });
+
+  // "ALL" 값을 가진 객체 제외
+  const filteredProgressSteps =
+    progressStepData?.filter((step) => step.value !== "ALL") || [];
+
+  const [progressStepId, setProgressStepId] = useState<number>(
+    filteredProgressSteps.length > 0 ? Number(filteredProgressSteps[0].id) : 0,
+  );
 
   const handleSave = async <T extends QuestionRequestData>(requestData: T) => {
     try {
@@ -56,10 +69,16 @@ export default function QuestionRegisterPage() {
       <BackButton />
 
       <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
-        <ProgressStepAddSection
+        {/* <ProgressStepAddSection
           progressStepId={progressStepId}
           setProgressStepId={setProgressStepId}
-          progressData={progressData}
+          progressData={filteredProgressSteps || []}
+        /> */}
+        <FormSelectInput
+          label="진행 단계"
+          selectedValue={progressStepId}
+          setSelectedValue={setProgressStepId}
+          options={filteredProgressSteps || []}
         />
       </ArticleForm>
     </Box>

--- a/src/components/pages/QuestionRegisterPage/index.tsx
+++ b/src/components/pages/QuestionRegisterPage/index.tsx
@@ -11,7 +11,7 @@ import { createQuestionApi } from "@/src/api/RegisterArticle";
 import { ProjectProgressStepProps, QuestionRequestData } from "@/src/types";
 import { fetchProjectQuestionProgressStep as fetchProjectQuestionProgressStepApi } from "@/src/api/projects";
 import { useFetchData } from "@/src/hook/useFetchData";
-import FormSelectInput from "../../common/FormSelectInput";
+import FormSelectInput from "@/src/components/common/FormSelectInput";
 
 export default function QuestionRegisterPage() {
   const { projectId } = useParams();

--- a/src/components/pages/TaskReadPage/index.tsx
+++ b/src/components/pages/TaskReadPage/index.tsx
@@ -1,86 +1,80 @@
-// // questionId 글 열람 페이지
-// "use client";
+// questionId 글 열람 페이지
+"use client";
 
-// // 외부 라이브러리
-// import { Box, VStack, Flex } from "@chakra-ui/react";
-// import { useParams } from "next/navigation";
-// import { useState, useEffect } from "react";
+// 외부 라이브러리
+import { Box, VStack, Flex } from "@chakra-ui/react";
+import { useParams } from "next/navigation";
+import { useState, useEffect } from "react";
 
-// // 절대 경로 파일
-// import ArticleContent from "@/src/components/common/ArticleContent";
-// // import ArticleComments from "@/src/components/common/ArticleComments";
-// import CommentBox from "@/src/components/common/CommentBox";
-// import BackButton from "@/src/components/common/BackButton";
-// import { readQuestionApi } from "@/src/api/ReadArticle";
-// import SignToApprove from "@/src/components/pages/TaskReadPage/components/SignToApprove";
-// import { Article } from "@/src/types";
+// 절대 경로 파일
+import ArticleContent from "@/src/components/common/ArticleContent";
+import ArticleComments from "@/src/components/common/ArticleComments";
+import CommentBox from "@/src/components/common/CommentBox";
+import BackButton from "@/src/components/common/BackButton";
+import { readQuestionApi } from "@/src/api/ReadArticle";
+import SignToApprove from "@/src/components/pages/TaskReadPage/components/SignToApprove";
+import { Article } from "@/src/types";
 
-// export default function TaskReadPage() {
-//   const { projectId, questionId } = useParams() as {
-//     projectId: string;
-//     questionId: string;
-//   };
+export default function TaskReadPage() {
+  const { projectId, questionId } = useParams() as {
+    projectId: string;
+    questionId: string;
+  };
 
-//   const [article, setArticle] = useState<Article | null>(null);
-//   const [error, setError] = useState<string | null>(null);
-//   const [loading, setLoading] = useState<boolean>(true);
+  const [article, setArticle] = useState<Article | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
-//   useEffect(() => {
-//     const loadTask = async () => {
-//       try {
-//         const data = await readQuestionApi(
-//           Number(projectId),
-//           Number(questionId),
-//         );
-//         setArticle(data);
-//       } catch (err) {
-//         setError(
-//           err instanceof Error
-//             ? err.message
-//             : "데이터를 가져오는데 실패했습니다.",
-//         );
-//       } finally {
-//         setLoading(false);
-//       }
-//     };
-//     loadTask();
-//   }, [projectId, questionId]);
+  useEffect(() => {
+    const loadTask = async () => {
+      try {
+        const data = await readQuestionApi(
+          Number(projectId),
+          Number(questionId),
+        );
+        setArticle(data);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "데이터를 가져오는데 실패했습니다.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadTask();
+  }, [projectId, questionId]);
 
-//   if (error) {
-//     return <Box>에러 발생: {error}</Box>;
-//   }
+  if (error) {
+    return <Box>에러 발생: {error}</Box>;
+  }
 
-//   if (loading) {
-//     return <Box>로딩 중...</Box>;
-//   }
+  if (loading) {
+    return <Box>로딩 중...</Box>;
+  }
 
-//   return (
-//     <Box
-//       maxW="1000px"
-//       w="100%"
-//       mx="auto"
-//       mt={10}
-//       p={6}
-//       borderWidth={1}
-//       borderRadius="lg"
-//       boxShadow="md"
-//     >
-//       <BackButton />
+  return (
+    <Box
+      maxW="1000px"
+      w="100%"
+      mx="auto"
+      mt={10}
+      p={6}
+      borderWidth={1}
+      borderRadius="lg"
+      boxShadow="md"
+    >
+      <BackButton />
 
-//       {/* 게시글 내용 */}
+      {/* 게시글 내용 */}
 
-//       <ArticleContent article={article} />
+      <ArticleContent article={article} />
 
-//       {/* 결재 사인 섹션 */}
-//       <Flex justifyContent={"center"}>
-//         <SignToApprove />
-//       </Flex>
-
-//       {/* 댓글 섹션 */}
-//       <VStack align="stretch" gap={8} mt={10}>
-//         {/* <ArticleComments comments={article?.commentList || []} /> */}
-//         <CommentBox />
-//       </VStack>
-//     </Box>
-//   );
-// }
+      {/* 결재 사인 섹션 */}
+      <Flex justifyContent={"center"}>
+        <SignToApprove />
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/pages/TaskRegisterPage/index.tsx
+++ b/src/components/pages/TaskRegisterPage/index.tsx
@@ -9,16 +9,16 @@ import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import ArticleForm from "@/src/components/common/ArticleForm";
 import { createTaskApi } from "@/src/api/RegisterArticle";
-import ProgressStepAddSection from "@/src/components/common/ProgressStepAddSection";
 import { TaskRequestData } from "@/src/types";
+import FormSelectInput from "@/src/components/common/FormSelectInput";
 
 const progressData = [
-  { id: 1, title: "요구사항정의" },
-  { id: 2, title: "화면설계" },
-  { id: 3, title: "디자인" },
-  { id: 4, title: "퍼블리싱" },
-  { id: 5, title: "개발" },
-  { id: 6, title: "검수" },
+  { id: "1", title: "요구사항정의", value: "" },
+  { id: "2", title: "화면설계", value: "" },
+  { id: "3", title: "디자인", value: "" },
+  { id: "4", title: "퍼블리싱", value: "" },
+  { id: "5", title: "개발", value: "" },
+  { id: "6", title: "검수", value: "" },
 ];
 
 export default function TaskRegisterPage() {
@@ -57,10 +57,16 @@ export default function TaskRegisterPage() {
       <BackButton />
 
       <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
-        <ProgressStepAddSection
+        {/* <ProgressStepAddSection
           progressStepId={progressStepId}
           setProgressStepId={setProgressStepId}
-          progressData={progressData}
+          progressData={progressData || []}
+        /> */}
+        <FormSelectInput
+          label="진행 단계"
+          selectedValue={progressStepId}
+          setSelectedValue={setProgressStepId}
+          options={progressData || []}
         />
       </ArticleForm>
     </Box>

--- a/src/components/pages/noticeRegisterPage/index.tsx
+++ b/src/components/pages/noticeRegisterPage/index.tsx
@@ -6,8 +6,8 @@ import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import { NoticeRequestData } from "@/src/types";
 import { createNoticeApi } from "@/src/api/notices";
-import ArticleForm from "@/src/components/common/ArticleForm";
 import SelectInput from "@/src/components/common/FormSelectInput";
+import dynamic from "next/dynamic";
 
 const categoryData = [
   { id: 1, title: "서비스업데이트", value: "SERVICE_UPDATE" },
@@ -19,6 +19,13 @@ const priorityData = [
   { id: 1, title: "긴급", value: "EMERGENCY" },
   { id: 2, title: "일반", value: "NORMAL" },
 ];
+
+const ArticleForm = dynamic(
+  () => import("@/src/components/common/ArticleForm"),
+  {
+    ssr: false,
+  },
+);
 
 export default function NoticeRegisterPage() {
   const [title, setTitle] = useState<string>("");
@@ -37,11 +44,9 @@ export default function NoticeRegisterPage() {
           ? { priority: requestData.priority }
           : {}),
       });
-      alert("저장이 완료되었습니다.");
       router.push(`/notices`);
     } catch (error) {
       console.error("저장 실패:", error);
-      alert("저장 중 문제가 발생했습니다.");
     }
   };
 

--- a/src/components/pages/noticeRegisterPage/index.tsx
+++ b/src/components/pages/noticeRegisterPage/index.tsx
@@ -1,9 +1,50 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
+import { NoticeRequestData } from "@/src/types";
+import { createNoticeApi } from "@/src/api/notices";
+import ArticleForm from "@/src/components/common/ArticleForm";
+import SelectInput from "@/src/components/common/FormSelectInput";
+
+const categoryData = [
+  { id: 1, title: "서비스업데이트", value: "SERVICE_UPDATE" },
+  { id: 2, title: "정책변경", value: "POLICY_CHANGE" },
+  { id: 3, title: "점검안내", value: "MAINTENANCE" },
+  { id: 4, title: "기타", value: "OTHER" },
+];
+const priorityData = [
+  { id: 1, title: "긴급", value: "EMERGENCY" },
+  { id: 2, title: "일반", value: "NORMAL" },
+];
 
 export default function NoticeRegisterPage() {
+  const [title, setTitle] = useState<string>("");
+  const [category, setCategory] = useState<string>("");
+  const [priority, setPriority] = useState<string>("");
+  const router = useRouter();
+
+  const handleSave = async <T extends NoticeRequestData>(requestData: T) => {
+    try {
+      const response = await createNoticeApi({
+        ...requestData,
+        ...(requestData.category !== undefined
+          ? { category: requestData.category }
+          : {}),
+        ...(requestData.priority !== undefined
+          ? { priority: requestData.priority }
+          : {}),
+      });
+      alert("저장이 완료되었습니다.");
+      router.push(`/notices`);
+    } catch (error) {
+      console.error("저장 실패:", error);
+      alert("저장 중 문제가 발생했습니다.");
+    }
+  };
+
   return (
     <Box
       maxW="1000px"
@@ -16,6 +57,23 @@ export default function NoticeRegisterPage() {
       boxShadow="md"
     >
       <BackButton />
+      <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
+        {/* 우선순위 선택 */}
+        <SelectInput
+          label="우선순위"
+          selectedValue={priority}
+          setSelectedValue={setPriority}
+          options={priorityData}
+        />
+
+        {/* 카테고리 선택 */}
+        <SelectInput
+          label="카테고리"
+          selectedValue={category}
+          setSelectedValue={setCategory}
+          options={categoryData}
+        />
+      </ArticleForm>
     </Box>
   );
 }

--- a/src/components/pages/noticesPage/index.tsx
+++ b/src/components/pages/noticesPage/index.tsx
@@ -52,7 +52,7 @@ function NoticesPageContent() {
   const router = useRouter();
 
   const keyword = searchParams?.get("keyword") || "";
-  const status = searchParams?.get("status") || "";
+  const category = searchParams?.get("category") || "";
   const currentPage = parseInt(searchParams?.get("currentPage") || "1", 10);
   const pageSize = parseInt(searchParams?.get("pageSize") || "5", 10);
 
@@ -74,7 +74,7 @@ function NoticesPageContent() {
   >({
     fetchApi: fetchNoticeListApi,
     keySelector: "notices",
-    params: [keyword, status, currentPage, pageSize],
+    params: [keyword, category, currentPage, pageSize],
   });
 
   const handlePageChange = (page: number) => {
@@ -107,8 +107,8 @@ function NoticesPageContent() {
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <FilterSelectBox
               statusFramework={noticeStatusFramework}
-              selectedValue={status}
-              queryKey="status"
+              selectedValue={category}
+              queryKey="category"
             />
           </SearchSection>
         </Flex>
@@ -118,7 +118,7 @@ function NoticesPageContent() {
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <FilterSelectBox
               statusFramework={noticeStatusFramework}
-              selectedValue={status}
+              selectedValue={category}
               queryKey="status"
             />
           </SearchSection>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -316,6 +316,7 @@ export interface NoticeListResponse {
 export interface ProjectProgressStepProps {
   id: string;
   title: string;
+  value: string;
   count: number;
 }
 
@@ -347,4 +348,9 @@ export interface QuestionRequestData extends BaseArticleRequestData {
 
 export interface TaskRequestData extends BaseArticleRequestData {
   progressStepId?: number;
+}
+
+export interface NoticeRequestData extends BaseArticleRequestData {
+  category?: string;
+  priority?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -317,7 +317,7 @@ export interface ProjectProgressStepProps {
   id: string;
   title: string;
   value: string;
-  count: number;
+  count?: number;
 }
 
 export interface UserInfoResponse {


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 공지사항 목록 API 연동 및 생성 API 연동
- Related to #79 

### 🔧 What has been changed?
- ProgressStepAddSection(추후 삭제 예정) 공통 컴포넌트화 -> FormSelectInput
- 공지사항 목록 API 연동 완료
- 공지사항 생성 API 연동 준비 완료
- 
### 📸 Screenshots / GIFs (if applicable)

### ⚠️ Precaution & Known issues
[추후 작업 예정]
- 공지사항 글 상세 조회 UI구현
- 공지사항 수정 삭제 기능 API 연동

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
