### PR TITLE
공통 패칭 훅 리팩토링 및 에러 처리 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -7,7 +7,7 @@ import {
 import { axiosForMiddleware } from "@/src/api/axiosForMiddleware";
 
 // 사용자 권한 API 호출
-export async function fetchUserInfo(
+export async function fetchUserInfoApi(
   accessToken?: string,
 ): Promise<CommonResponseType<UserInfoResponse>> {
   const response = await axiosForMiddleware.get("/me", {

--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -9,7 +9,7 @@ import {
 } from "@/src/types";
 
 // 📌 회원 목록 Fetch API
-export async function fetchMemberList(
+export async function fetchMemberListApi(
   keyword: string = "", // 검색키워드
   role: string = "", // 계정타입
   status: string = "", // 활성화여부

--- a/src/api/notices.ts
+++ b/src/api/notices.ts
@@ -1,7 +1,7 @@
 import { CommonResponseType, NoticeListResponse, NoticeRequestData } from "@/src/types";
 import axiosInstance from "@/src/api/axiosInstance";
 
-export async function fetchNoticeList(
+export async function fetchNoticeListApi(
   keyword: string = "", // 검색키워드
   category: string = "", // 활성화여부
   currentPage: number,

--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -9,7 +9,7 @@ import {
 } from "@/src/types";
 
 // 📌 업체 목록 Fetch API
-export async function fetchOrganizationList(
+export async function fetchOrganizationListApi(
   keyword: string = "", // 검색어
   type: string = "", // 업체타입
   status: string = "", // 활성화여부

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import type { Metadata } from "next";
 import { Provider as ChakraProvider } from "@/src/components/ui/provider";
+import { Toaster } from "@/src/components/ui/toaster";
 
 // import { MSWComponent } from "@/src/components/common/MSWComponent";
 
@@ -20,6 +21,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html suppressHydrationWarning>
       <body>
         <ChakraProvider>
+          <Toaster />
           {/* {useMsw ? <MSWComponent>{children}</MSWComponent> : children} */}
           {children}
         </ChakraProvider>

--- a/src/components/common/ErrorAlert.tsx
+++ b/src/components/common/ErrorAlert.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Alert } from "@chakra-ui/react";
+
+interface ErrorAlertProps {
+  status?: "error" | "warning" | "info"; // 기본값 error
+  message: string;
+}
+
+const ErrorAlert = ({ status = "error", message }: ErrorAlertProps) => {
+  return (
+    <Alert.Root status={status}>
+      <Alert.Indicator />
+      <Alert.Title>{message}</Alert.Title>
+    </Alert.Root>
+  );
+};
+
+export default ErrorAlert;

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -7,7 +7,6 @@ import { Layers, List, MessageCircleQuestion } from "lucide-react";
 import { SegmentedControl } from "@/src/components/ui/segmented-control";
 import ProjectInfoSection from "@/src/components/common/ProjectInfoSection";
 import { useProjectInfo } from "@/src/hook/useFetchData";
-import { Toaster } from "@/src/components/ui/toaster";
 
 interface ProjectLayoutProps {
   children: ReactNode;
@@ -69,7 +68,6 @@ export function ProjectLayout({ children }: ProjectLayoutProps) {
 
   return (
     <>
-      <Toaster />
       {projectInfoError && (
         <Alert.Root status="error">
           <Alert.Indicator />

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -4,20 +4,12 @@ import { Box, CardRoot, Flex, Heading } from "@chakra-ui/react";
 import { SegmentedControl } from "@/src/components/ui/segmented-control";
 import SidebarTab from "@/src/components/layouts/SidebarTab";
 import { useSidebar } from "@/src/context/SidebarContext";
-import { fetchUserInfo as fetchUserInfoApi } from "@/src/api/auth";
-import { useFetchData } from "@/src/hook/useFetchData";
-import { UserInfoResponse } from "@/src/types";
+import { useUserInfo } from "@/src/hook/useFetchData";
 import { Loading } from "../common/Loading";
 
 export default function Sidebar() {
   const { selectedProjectFilter, setSelectedProjectFilter } = useSidebar();
-  const { data: userInfoData, loading: userInfoLoading } = useFetchData<
-    UserInfoResponse,
-    []
-  >({
-    fetchApi: fetchUserInfoApi,
-    params: [],
-  });
+  const { data: userInfoData, loading: userInfoLoading } = useUserInfo();
 
   const userRole = userInfoData?.role;
 

--- a/src/components/pages/QuestionRegisterPage/index.tsx
+++ b/src/components/pages/QuestionRegisterPage/index.tsx
@@ -8,11 +8,12 @@ import { Box } from "@chakra-ui/react";
 import BackButton from "@/src/components/common/BackButton";
 import ArticleForm from "@/src/components/common/ArticleForm";
 import { createQuestionApi } from "@/src/api/RegisterArticle";
-import { ProjectProgressStepProps, QuestionRequestData } from "@/src/types";
-import { fetchProjectQuestionProgressStepApi } from "@/src/api/projects";
-import { useFetchData } from "@/src/hook/useFetchData";
+import { QuestionRequestData } from "@/src/types";
+import { useProjectApprovalProgressStepData } from "@/src/hook/useFetchData";
 import FormSelectInput from "@/src/components/common/FormSelectInput";
 import "@/src/components/pages/QuestionRegisterPage/edit.css";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
+import { Loading } from "@/src/components/common/Loading";
 
 export default function QuestionRegisterPage() {
   const { projectId } = useParams();
@@ -24,17 +25,15 @@ export default function QuestionRegisterPage() {
     : projectId || "";
 
   // ProgressStep 데이터 패칭
-  const { data: progressStepData } = useFetchData<
-    ProjectProgressStepProps[],
-    [string]
-  >({
-    fetchApi: fetchProjectQuestionProgressStepApi,
-    params: [resolvedProjectId],
-  });
+  const {
+    data: approvalProgressStepData,
+    loading: approvalProgressStepLoading,
+    error: approvalProgressStepError,
+  } = useProjectApprovalProgressStepData(resolvedProjectId);
 
   // "ALL" 값을 가진 객체 제외
   const filteredProgressSteps =
-    progressStepData?.filter((step) => step.value !== "ALL") || [];
+    approvalProgressStepData?.filter((step) => step.value !== "ALL") || [];
 
   const [progressStepId, setProgressStepId] = useState<number>(
     filteredProgressSteps.length > 0 ? Number(filteredProgressSteps[0].id) : 0,
@@ -56,6 +55,8 @@ export default function QuestionRegisterPage() {
     }
   };
 
+  if (approvalProgressStepLoading) return <Loading />;
+
   return (
     <Box
       maxW="1000px"
@@ -70,6 +71,9 @@ export default function QuestionRegisterPage() {
       <BackButton />
 
       <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave}>
+        {approvalProgressStepError && (
+          <ErrorAlert message="프로젝트 질문 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
         <FormSelectInput
           label="진행 단계"
           selectedValue={progressStepId}

--- a/src/components/pages/adminMembersPage/index.tsx
+++ b/src/components/pages/adminMembersPage/index.tsx
@@ -13,12 +13,11 @@ import {
 import StatusTag from "@/src/components/common/StatusTag";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
-import { formatDateWithTime } from "@/src/utils/formatDateUtil";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
 import SearchSection from "@/src/components/common/SearchSection";
 import FilterSelectBox from "@/src/components/common/FilterSelectBox";
-import { MemberListResponse } from "@/src/types";
-import { useFetchBoardList } from "@/src/hook/useFetchBoardList";
-import { fetchMemberList as fetchMemberListApi } from "@/src/api/members";
+import { useMemberList } from "@/src/hook/useFetchBoardList";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
 
 const memberRoleFramework = createListCollection<{
   label: string;
@@ -73,15 +72,8 @@ function AdminMembersPageContent() {
     data: memberList,
     paginationInfo,
     loading: memberListLoading,
-  } = useFetchBoardList<
-    MemberListResponse,
-    [string, string, string, number, number],
-    "members"
-  >({
-    fetchApi: fetchMemberListApi,
-    keySelector: "members",
-    params: [keyword, role, status, currentPage, pageSize],
-  });
+    error: memberListError,
+  } = useMemberList(keyword, role, status, currentPage, pageSize);
 
   // 신규등록 버튼 클릭 시 - 회원 등록 페이지로 이동
   const handleMemberCreateButton = () => {
@@ -128,6 +120,9 @@ function AdminMembersPageContent() {
             />
           </SearchSection>
         </Box>
+        {memberListError && (
+          <ErrorAlert message="공지사항 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
         <CommonTable
           headerTitle={
             <Table.Row
@@ -163,7 +158,7 @@ function AdminMembersPageContent() {
                   {STATUS_LABELS[member.status] || "알 수 없음"}
                 </StatusTag>
               </Table.Cell>
-              <Table.Cell>{formatDateWithTime(member.regAt)}</Table.Cell>
+              <Table.Cell>{formatDynamicDate(member.regAt)}</Table.Cell>
             </>
           )}
           handleRowClick={handleRowClick}

--- a/src/components/pages/adminOrganizationsPage/index.tsx
+++ b/src/components/pages/adminOrganizationsPage/index.tsx
@@ -13,11 +13,11 @@ import {
 import StatusTag from "@/src/components/common/StatusTag";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
-import { useFetchBoardList } from "@/src/hook/useFetchBoardList";
-import { OrganizationListResponse } from "@/src/types";
-import { fetchOrganizationList as fetchOrganizationListApi } from "@/src/api/organizations";
+import { useOrganizationList } from "@/src/hook/useFetchBoardList";
 import SearchSection from "@/src/components/common/SearchSection";
 import FilterSelectBox from "@/src/components/common/FilterSelectBox";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
 
 const organizationTypeFramework = createListCollection<{
   label: string;
@@ -73,15 +73,8 @@ function AdminOrganizationsPageContent() {
     data: organizationList,
     paginationInfo,
     loading: organizationListLoading,
-  } = useFetchBoardList<
-    OrganizationListResponse,
-    [string, string, string, number, number],
-    "dtoList"
-  >({
-    fetchApi: fetchOrganizationListApi,
-    keySelector: "dtoList",
-    params: [keyword, type, status, currentPage, pageSize],
-  });
+    error: organizationListError,
+  } = useOrganizationList(keyword, type, status, currentPage, pageSize);
 
   // 신규등록 버튼 클릭 시 - 업체 등록 페이지로 이동
   const handleMemberCreateButton = () => {
@@ -128,6 +121,9 @@ function AdminOrganizationsPageContent() {
             />
           </SearchSection>
         </Box>
+        {organizationListError && (
+          <ErrorAlert message="공지사항 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
         <CommonTable
           headerTitle={
             <Table.Row
@@ -142,6 +138,7 @@ function AdminOrganizationsPageContent() {
               <Table.ColumnHeader>연락처</Table.ColumnHeader>
               <Table.ColumnHeader>주소</Table.ColumnHeader>
               <Table.ColumnHeader>상태</Table.ColumnHeader>
+              <Table.ColumnHeader>등록일</Table.ColumnHeader>
             </Table.Row>
           }
           data={organizationList}
@@ -160,6 +157,7 @@ function AdminOrganizationsPageContent() {
                   {STATUS_LABELS[organization.status] || "알 수 없음"}
                 </StatusTag>
               </Table.Cell>
+              <Table.Cell>{formatDynamicDate(organization.regAt)}</Table.Cell>
             </>
           )}
           handleRowClick={handleRowClick}

--- a/src/components/pages/projectApprovalsPage/index.tsx
+++ b/src/components/pages/projectApprovalsPage/index.tsx
@@ -2,7 +2,6 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
-  Alert,
   Box,
   Button,
   Flex,
@@ -20,6 +19,7 @@ import { useProjectApprovalProgressStepData } from "@/src/hook/useFetchData";
 import { useProjectApprovalList } from "@/src/hook/useFetchBoardList";
 import ProgressStepSection from "@/src/components/common/ProgressStepSection";
 import GuideButton from "@/src/components/common/GuideButton";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
 
 const taskStatusFramework = createListCollection<{
   id: string;
@@ -92,12 +92,7 @@ export default function ProjectTasksPage() {
   return (
     <ProjectLayout>
       {approvalProgressStepError && (
-        <Alert.Root status="error">
-          <Alert.Indicator />
-          <Alert.Title>
-            프로젝트 단계 정보를 불러오지 못했습니다. 다시 시도해주세요.
-          </Alert.Title>
-        </Alert.Root>
+        <ErrorAlert message="프로젝트 단계 정보를 불러오지 못했습니다. 다시 시도해주세요." />
       )}
       {/* 프로젝트 단계 섹션 */}
       <ProgressStepSection
@@ -134,12 +129,7 @@ export default function ProjectTasksPage() {
           </SearchSection>
         </Flex>
         {projectApprovalError && (
-          <Alert.Root status="error" mt={4}>
-            <Alert.Indicator />
-            <Alert.Title>
-              프로젝트 결제 목록을 불러오지 못했습니다. 다시 시도해주세요.
-            </Alert.Title>
-          </Alert.Root>
+          <ErrorAlert message="프로젝트 결제 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
         {/* 
           CommonTable: 게시글 목록을 렌더링하는 공통 테이블 컴포넌트

--- a/src/components/pages/projectQuestionsPage/index.tsx
+++ b/src/components/pages/projectQuestionsPage/index.tsx
@@ -2,7 +2,6 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
-  Alert,
   Box,
   Button,
   createListCollection,
@@ -19,6 +18,7 @@ import ProgressStepSection from "@/src/components/common/ProgressStepSection";
 import { formatDynamicDate } from "@/src/utils/formatDateUtil";
 import { useProjectQuestionList } from "@/src/hook/useFetchBoardList";
 import { useProjectQuestionProgressStepData } from "@/src/hook/useFetchData";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
 
 const questionStatusFramework = createListCollection<{
   id: string;
@@ -38,7 +38,7 @@ const STATUS_LABELS: Record<string, string> = {
   QUESTION: "질문",
   ANSWER: "답변",
 };
-  
+
 export default function ProjectQuestionsPage() {
   const { projectId } = useParams();
   const searchParams = useSearchParams();
@@ -95,12 +95,7 @@ export default function ProjectQuestionsPage() {
     <ProjectLayout>
       {/* 프로젝트 단계 섹션 */}
       {questionProgressStepError && (
-        <Alert.Root status="error">
-          <Alert.Indicator />
-          <Alert.Title>
-            프로젝트 단계 정보를 불러오지 못했습니다. 다시 시도해주세요.
-          </Alert.Title>
-        </Alert.Root>
+        <ErrorAlert message="프로젝트 단계 정보를 불러오지 못했습니다. 다시 시도해주세요." />
       )}
       <ProgressStepSection
         progressStep={questionProgressStepData || []}
@@ -135,12 +130,7 @@ export default function ProjectQuestionsPage() {
           </SearchSection>
         </Flex>
         {projectQuestionError && (
-          <Alert.Root status="error" mt={4}>
-            <Alert.Indicator />
-            <Alert.Title>
-              프로젝트 질문 목록을 불러오지 못했습니다. 다시 시도해주세요.
-            </Alert.Title>
-          </Alert.Root>
+          <ErrorAlert message="프로젝트 질문 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
         {/* 
           CommonTable: 게시글 목록을 렌더링하는 공통 테이블 컴포넌트

--- a/src/components/pages/projectsPage/index.tsx
+++ b/src/components/pages/projectsPage/index.tsx
@@ -4,15 +4,15 @@ import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Head from "next/head";
 import { createListCollection, Heading, Stack, Table } from "@chakra-ui/react";
-import { fetchProjectListApi } from "@/src/api/projects";
 import StatusTag from "@/src/components/common/StatusTag";
 import ProjectStatusCards from "@/src/components/pages/projectsPage/components/ProjectsStatusCards";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
 import SearchSection from "@/src/components/common/SearchSection";
 import StatusSelectBox from "@/src/components/common/FilterSelectBox";
-import { useFetchBoardList } from "@/src/hook/useFetchBoardList";
-import { ProjectListResponse } from "@/src/types";
+import { useProjectList } from "@/src/hook/useFetchBoardList";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
 
 const projectStatusFramework = createListCollection<{
   label: string;
@@ -67,15 +67,8 @@ function ProjectsPageContent() {
     data: projectList,
     paginationInfo,
     loading: projectListLoading,
-  } = useFetchBoardList<
-    ProjectListResponse,
-    [string, string, number, number],
-    "projects"
-  >({
-    fetchApi: fetchProjectListApi,
-    keySelector: "projects",
-    params: [keyword, status, currentPage, pageSize],
-  });
+    error: projectListError,
+  } = useProjectList(keyword, status, currentPage, pageSize);
 
   /**
    * 페이지 변경 시 호출되는 콜백 함수
@@ -98,7 +91,7 @@ function ProjectsPageContent() {
    * @param id 프로젝트 ID (백엔드 혹은 테이블에서 받아온 값)
    */
   const handleRowClick = (id: string) => {
-    router.push(`/projects/${id}/tasks`);
+    router.push(`/projects/${id}/approvals`);
   };
 
   return (
@@ -136,6 +129,9 @@ function ProjectsPageContent() {
             queryKey="status"
           />
         </SearchSection>
+        {projectListError && (
+          <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
         {/*
          * 공통 테이블(CommonTable)
          *  - headerTitle: 테이블 헤더 구성
@@ -155,7 +151,7 @@ function ProjectsPageContent() {
               <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
               <Table.ColumnHeader>고객사</Table.ColumnHeader>
               <Table.ColumnHeader>개발사</Table.ColumnHeader>
-              <Table.ColumnHeader>프로젝트 상태</Table.ColumnHeader>
+              <Table.ColumnHeader>프로젝트 관리단계</Table.ColumnHeader>
               <Table.ColumnHeader>프로젝트 시작일</Table.ColumnHeader>
               <Table.ColumnHeader>프로젝트 종료일</Table.ColumnHeader>
             </Table.Row>
@@ -172,8 +168,8 @@ function ProjectsPageContent() {
                   {STATUS_LABELS[project.status] || "알 수 없음"}
                 </StatusTag>
               </Table.Cell>
-              <Table.Cell>{project.startAt}</Table.Cell>
-              <Table.Cell>{project.closeAt}</Table.Cell>
+              <Table.Cell>{formatDynamicDate(project.startAt)}</Table.Cell>
+              <Table.Cell>{formatDynamicDate(project.closeAt)}</Table.Cell>
             </>
           )}
           handleRowClick={handleRowClick}

--- a/src/hook/useFetchBoardList.ts
+++ b/src/hook/useFetchBoardList.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
-import { CommonResponseWithMetaType, PaginationProps, ProjectQuestionListResponse, ProjectApprovalListResponse } from "@/src/types";
-import { fetchProjectQuestionListApi, fetchProjectApprovalListApi } from "@/src/api/projects";
+import { CommonResponseWithMetaType, PaginationProps, ProjectQuestionListResponse, ProjectApprovalListResponse, ProjectListResponse, NoticeListResponse, OrganizationListResponse, MemberListResponse } from "@/src/types";
+import { fetchProjectQuestionListApi, fetchProjectApprovalListApi, fetchProjectListApi } from "@/src/api/projects";
 import { showToast } from "@/src/utils/showToast";
+import { fetchNoticeListApi } from "@/src/api/notices";
+import { fetchOrganizationListApi } from "@/src/api/organizations";
+import { fetchMemberListApi } from "@/src/api/members";
 
 interface UseFetchBoardListProps<T, P extends any[], K extends keyof T> {
   fetchApi: (...args: P) => Promise<CommonResponseWithMetaType<T>>;
@@ -111,3 +114,71 @@ export const useProjectApprovalList = (
     pageSize,
   ],
 });
+
+// 프로젝트 목록 패칭
+export const useProjectList = (
+  keyword: string,
+  status: string,
+  currentPage: number,
+  pageSize: number
+) => useFetchBoardList<
+ProjectListResponse,
+[string, string, number, number],
+"projects"
+>({
+fetchApi: fetchProjectListApi,
+keySelector: "projects",
+params: [keyword, status, currentPage, pageSize],
+});
+
+// 공지사항 목록 패칭
+export const useNoticeList = (
+  keyword: string,
+  status: string,
+  currentPage: number,
+  pageSize: number
+) => useFetchBoardList<
+NoticeListResponse,
+[string, string, number, number],
+"notices"
+>({
+fetchApi: fetchNoticeListApi,
+keySelector: "notices",
+params: [keyword, status, currentPage, pageSize],
+});
+
+// 회원 목록 패칭
+export const useMemberList = (
+  keyword: string,
+  role: string,
+  status: string,
+  currentPage: number,
+  pageSize: number
+) => 
+useFetchBoardList<
+    MemberListResponse,
+    [string, string, string, number, number],
+    "members"
+  >({
+    fetchApi: fetchMemberListApi,
+    keySelector: "members",
+    params: [keyword, role, status, currentPage, pageSize],
+  });
+
+// 업체 목록 패칭
+export const useOrganizationList = (
+  keyword: string,
+  type: string,
+  status: string,
+  currentPage: number,
+  pageSize: number
+) => 
+useFetchBoardList<
+    OrganizationListResponse,
+    [string, string, string, number, number],
+    "dtoList"
+  >({
+    fetchApi: fetchOrganizationListApi,
+    keySelector: "dtoList",
+    params: [keyword, type, status, currentPage, pageSize],
+  });

--- a/src/hook/useFetchData.ts
+++ b/src/hook/useFetchData.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { CommonResponseType, ProjectInfoProps, ProjectProgressStepProps } from "@/src/types";
+import { CommonResponseType, ProjectInfoProps, ProjectProgressStepProps, UserInfoResponse } from "@/src/types";
 import { fetchProjectApprovalProgressStepApi, fetchProjectInfoApi, fetchProjectQuestionProgressStepApi } from "@/src/api/projects";
 import { showToast } from "@/src/utils/showToast";
+import { fetchUserInfoApi } from "@/src/api/auth";
 
 interface UseFetchDataProps<T, P extends any[]> {
   fetchApi: (...args: P) => Promise<CommonResponseType<T>>;
@@ -57,7 +58,7 @@ export function useFetchData<T, P extends any[]>({
 }
 
 /**
- * 프로젝트 Progress Step 데이터 패칭 훅
+ * 프로젝트 질문 Progress Step 데이터 패칭 훅
  */
 export const useProjectQuestionProgressStepData = (resolvedProjectId: string) =>
   useFetchData<ProjectProgressStepProps[], [string]>({
@@ -82,3 +83,8 @@ export const useProjectApprovalProgressStepData = (resolvedProjectId: string) =>
     fetchApi: fetchProjectApprovalProgressStepApi,
     params: [resolvedProjectId],
   });
+
+export const useUserInfo = () => useFetchData<UserInfoResponse, []>({
+  fetchApi: fetchUserInfoApi,
+  params: []
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { fetchReissueToken, fetchUserInfo } from "@/src/api/auth";
+import { fetchReissueToken, fetchUserInfoApi } from "@/src/api/auth";
 import { UserInfoResponse } from "./types";
 
 // const ADMIN_ONLY_PAGE = ["admin", "super-admin"];
@@ -66,7 +66,7 @@ async function validateAndRefreshTokens(
   try {
     // 🔹 1. AccessToken 검증
     if (accessToken) {
-      userInfoResponse = await fetchUserInfo(accessToken);
+      userInfoResponse = await fetchUserInfoApi(accessToken);
       if (userInfoResponse.result === "SUCCESS") {
         return { userInfo: userInfoResponse.data, response };
       }
@@ -97,7 +97,7 @@ async function validateAndRefreshTokens(
         );
 
         // 🔹 3. 재발급된 AccessToken으로 사용자 정보 가져오기
-        userInfoResponse = await fetchUserInfo(reissueResponse.data.access);
+        userInfoResponse = await fetchUserInfoApi(reissueResponse.data.access);
         if (userInfoResponse.result === "SUCCESS") {
           return { userInfo: userInfoResponse.data, response };
         }
@@ -127,7 +127,7 @@ async function validateAndRefreshTokens(
       setAuthCookies(response, reissueResponse.data.access, reissueResponse.data.refresh);
 
       // 새 Access Token으로 유저 정보 가져오기
-      const userInfoResponse = await fetchUserInfo(reissueResponse.data.access);
+      const userInfoResponse = await fetchUserInfoApi(reissueResponse.data.access);
       if (userInfoResponse.result === "SUCCESS") {
         return { userInfo: userInfoResponse.data, response };
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,7 @@ export interface OrganizationProps {
   status: string;
   brNumber: string;
   name: string;
-  reg_at: string;
+  regAt: string;
   brCertificateUrl: string;
   streetAddress: string;
   detailAddress: string;

--- a/src/utils/formatDateUtil.ts
+++ b/src/utils/formatDateUtil.ts
@@ -17,8 +17,9 @@ export const formatDateWithTime = (dateString: string) => {
 
 export function formatDateToISODate(dateString: string | null | undefined): string {
   if (!dateString) return ""; // dateString이 null 또는 undefined이면 빈 문자열 반환
-  const date = new Date(dateString);
-  return date.toISOString().split("T")[0]; // "yyyy-mm-dd"
+
+  const givenDate = new Date(dateString.replace(" ", "T")); // "yyyy-mm-dd hh:mm" → "yyyy-mm-ddThh:mm"
+  return givenDate.toISOString().split("T")[0]; // yyyy-mm-dd
 }
 
 
@@ -26,16 +27,18 @@ export function formatDynamicDate(dateString: string | null | undefined): string
   if (!dateString) return ""; // dateString이 null 또는 undefined이면 빈 문자열 반환
 
   const now = new Date();
-  const givenDate = new Date(dateString);
+  const givenDate = new Date(dateString.replace(" ", "T")); // "yyyy-mm-dd hh:mm" → "yyyy-mm-ddThh:mm"
 
-  // 당일 여부 확인
+  // 오늘 날짜인지 확인
   const isToday =
     now.getFullYear() === givenDate.getFullYear() &&
     now.getMonth() === givenDate.getMonth() &&
     now.getDate() === givenDate.getDate();
 
-  // 당일이면 시간(hh:mm), 그렇지 않으면 yyyy-mm-dd 형식 반환
-  return isToday ? formatDateWithTime(dateString).split(" ")[1] : formatDateToISODate(dateString);
+  // 오늘이면 "hh:mm", 아니면 "yyyy-mm-dd" 반환
+  return isToday
+    ? givenDate.toTimeString().slice(0, 5) // hh:mm
+    : givenDate.toISOString().split("T")[0]; // yyyy-mm-dd
 }
 
 // 게시글, 댓글에 사용할거


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 공통 패칭 훅 리팩토링 및 에러 처리 추가
- Close #150 

### 🔧 What has been changed?

- Toaster 컴포넌트 최상위 레이아웃 적용
- ProjectPage의 handleClick 경로 approval로 변경
- ErrorAlert 공통컴포넌트 추가
- 프로젝트 리스트, 질문/결제 리스트, 공지사항, 회원/업체 리스트 훅 간소화 및 에러처리

### 📸 Screenshots / GIFs (if applicable)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
