### PR TITLE
error: 메인 대시보드 UI 버그 수정

### DIFF
--- a/src/components/pages/ProjectsPage/index.tsx
+++ b/src/components/pages/ProjectsPage/index.tsx
@@ -123,26 +123,6 @@ function ProjectsPageContent() {
           content="FlowSync로 프로젝트 관리를 한번에"
         />
       </Head>
-      {/*
-       * 프로젝트 상태 카드 컴포넌트:
-       * 프로젝트 현황(예: 진행 중, 완료 등)을 시각적으로 표시합니다.
-       * title prop으로 "프로젝트 현황"을 전달.
-       */}
-      <ProjectStatusCards title={"프로젝트 현황"} />
-      <Stack width="full">
-        {/* 페이지 최상단 제목 */}
-        <Heading size="2xl" color="gray.600">
-          프로젝트 목록
-        </Heading>
-        {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
-        <SearchSection keyword={keyword} placeholder="프로젝트명 입력">
-          <StatusSelectBox
-            statusFramework={projectStatusFramework}
-            selectedValue={status}
-            queryKey="status"
-          />
-        </SearchSection>
-      </Stack>
 
       <Box bg={bgColor} p="4" minHeight="100vh">
         <Stack spaceY="SECTION_SPACING">


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 :메인 대시보드 UI 버그 수정
- Related to #158 

### 🔧 What has been changed?
메인 대시보드 현황판 컴포넌트 두 개 뜨던 에러 수정

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/0368b2f1-bfce-4198-ba21-087d7582200a)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
