### PR TITLE
진척관리게시판 관리단계 변경 기능 구현

### DIFF
--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -83,6 +83,16 @@ export async function projectProgressStepApi(projectId: string) {
   return response.data;
 }
 
+// 프로젝트 관리 단계 수정
+export async function projectManagementStepApi(projectId: string, managementStep: string) {
+  const response = await axiosInstance.put(
+    `/projects/${projectId}/management-steps`, {},{
+      params: {managementStep}
+    }
+  );
+  return response.data;
+}
+
 /**
  * 프로젝트 관리단계별 개수를 가져옵니다.
  * 예: 진행 중, 완료 등 관리단계별 프로젝트 수

--- a/src/app/(dashboard)/projects/[projectId]/layout.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/layout.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ProjectInfoProvider } from "@/src/context/ProjectInfoContext";
+import { useParams } from "next/navigation";
+import { ReactNode } from "react";
+
+interface layoutProps {
+  children: ReactNode;
+}
+
+export default function ProjectLayout({ children }: layoutProps) {
+  const { projectId } = useParams();
+  return (
+    <ProjectInfoProvider projectId={projectId as string}>
+      {children}
+    </ProjectInfoProvider>
+  );
+}

--- a/src/app/(dashboard)/projects/layout.tsx
+++ b/src/app/(dashboard)/projects/layout.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
 
-interface layoutProps {
+interface LayoutProps {
   children: ReactNode;
 }
 
-export default function layout({ children }: layoutProps) {
+export default function Layout({ children }: LayoutProps) {
   return <div>{children}</div>;
 }

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -8,7 +8,6 @@ import {
   DialogHeader,
   DialogRoot,
   DialogTitle,
-  DialogTrigger,
 } from "@/src/components/ui/dialog";
 
 interface ConfirmDialogProps {
@@ -19,6 +18,7 @@ interface ConfirmDialogProps {
   description: string;
   confirmText?: string;
   cancelText?: string;
+  isLoading?: boolean;
 }
 
 export default function ConfirmDialog({
@@ -29,25 +29,101 @@ export default function ConfirmDialog({
   description,
   confirmText = "확인",
   cancelText = "취소",
+  isLoading = false,
 }: ConfirmDialogProps) {
   return (
-    <DialogRoot open={isOpen}>
-      <DialogContent>
+    <DialogRoot open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        style={{
+          position: "fixed", // 화면 고정
+          top: "50%", // 화면 세로 중앙 정렬
+          left: "50%", // 화면 가로 중앙 정렬
+          transform: "translate(-50%, -50%)", // 정확한 중앙 정렬
+          padding: "24px", // 내부 패딩 추가
+          borderRadius: "12px", // 둥근 모서리
+          boxShadow: "0 4px 10px rgba(0, 0, 0, 0.1)", // 그림자 효과 추가
+          backgroundColor: "white", // 배경색 (다크모드 고려 시 Chakra의 `useColorModeValue` 사용 가능)
+          width: "400px", // 고정된 너비 설정
+          maxHeight: "250px", // 모달 길이 제한
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+        }}
+      >
+        <DialogCloseTrigger
+          onClick={onClose}
+          style={{
+            position: "absolute",
+            top: "12px",
+            right: "12px",
+            backgroundColor: "white", // X 버튼 배경을 흰색으로
+            border: "none",
+            cursor: "pointer",
+            fontSize: "18px",
+          }}
+        >
+          ✖
+        </DialogCloseTrigger>
+
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+          <DialogTitle
+            style={{
+              textAlign: "center",
+              fontSize: "20px",
+              fontWeight: "bold",
+            }}
+          >
+            {title}
+          </DialogTitle>
         </DialogHeader>
+
         <DialogBody>
-          <p>{description}</p>
+          <p
+            style={{ textAlign: "center", fontSize: "16px", margin: "10px 0" }}
+          >
+            {description}
+          </p>
         </DialogBody>
-        <DialogFooter>
+
+        <DialogFooter
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "10px",
+            width: "100%",
+          }}
+        >
+          {/* 확인 버튼 (더 길고 가독성 좋게) */}
+          <Button
+            onClick={onConfirm}
+            loading={isLoading}
+            loadingText="처리 중..."
+            colorScheme="blue"
+            disabled={isLoading}
+            style={{
+              width: "100%", // 버튼을 더 길게 설정
+              padding: "12px",
+              fontSize: "16px",
+            }}
+          >
+            {confirmText}
+          </Button>
+          {/* 취소 버튼 (더 길고 가독성 좋게) */}
           <DialogActionTrigger asChild>
-            <Button variant="outline" onClick={onClose}>
+            <Button
+              variant="outline"
+              onClick={onClose}
+              disabled={isLoading}
+              style={{
+                width: "100%", // 버튼을 더 길게 설정
+                padding: "12px",
+                fontSize: "16px",
+              }}
+            >
               {cancelText}
             </Button>
           </DialogActionTrigger>
-          <Button onClick={onConfirm}>{confirmText}</Button>
         </DialogFooter>
-        <DialogCloseTrigger />
       </DialogContent>
     </DialogRoot>
   );

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -11,11 +11,11 @@ interface SearchSectionProps {
 }
 
 export default function SearchSection({
-  keyword,
+  keyword = "",
   placeholder = "검색어를 입력하세요",
   children,
 }: SearchSectionProps) {
-  const [input, setInput] = useState<string>();
+  const [input, setInput] = useState<string>("");
   const router = useRouter();
 
   // 검색 버튼을 클릭하거나 엔터 입력시 데이터를 가져오는 함수

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -6,8 +6,8 @@ import { Flex, Heading, HStack, Text } from "@chakra-ui/react";
 import { Layers, List, MessageCircleQuestion } from "lucide-react";
 import { SegmentedControl } from "@/src/components/ui/segmented-control";
 import ProjectInfoSection from "@/src/components/common/ProjectInfoSection";
-import { useProjectInfo } from "@/src/hook/useFetchData";
 import ErrorAlert from "@/src/components/common/ErrorAlert";
+import { useProjectInfoContext } from "@/src/context/ProjectInfoContext";
 
 interface ProjectLayoutProps {
   children: ReactNode;
@@ -44,20 +44,26 @@ const projectMenu = [
   },
 ];
 
+const MANAGEMENT_STEP_LABELS: Record<string, string> = {
+  CONTRACT: "계약",
+  IN_PROGRESS: "진행중",
+  COMPLETED: "납품완료",
+  MAINTENANCE: "하자보수",
+  PAUSED: "일시중단",
+  DELETED: "삭제",
+};
+
 export function ProjectLayout({ children }: ProjectLayoutProps) {
   const router = useRouter();
   const { projectId } = useParams();
   const pathname = usePathname();
 
-  const resolvedProjectId = Array.isArray(projectId)
-    ? projectId[0]
-    : projectId || "";
   // 프로젝트 정보 데이터 패칭
   const {
     data: projectInfo,
     loading: projectInfoLoading,
     error: projectInfoError,
-  } = useProjectInfo(resolvedProjectId);
+  } = useProjectInfoContext();
   // 현재 탭 추출
   const currentTab = pathname.split("/").pop(); // "approvals" | "questions" | "workflow"
 
@@ -98,7 +104,7 @@ export function ProjectLayout({ children }: ProjectLayoutProps) {
             </Text>
           </Flex>
           <Text fontWeight="500" fontSize="20px">
-            {projectInfo?.managementStep}
+            {MANAGEMENT_STEP_LABELS[projectInfo?.managementStep || ""]}
           </Text>
         </Flex>
         {/* 프로젝트 정보 */}

--- a/src/components/pages/ProjectQuestionsNewPage/index.tsx
+++ b/src/components/pages/ProjectQuestionsNewPage/index.tsx
@@ -10,12 +10,9 @@ import ArticleForm from "@/src/components/common/ArticleForm";
 import { createQuestionApi } from "@/src/api/RegisterArticle";
 import { QuestionRequestData } from "@/src/types";
 import { projectProgressStepApi } from "@/src/api/projects";
-import { useProjectApprovalProgressStepData } from "@/src/hook/useFetchData";
 import { useFetchData } from "@/src/hook/useFetchData";
 import FormSelectInput from "@/src/components/common/FormSelectInput";
 import "@/src/components/pages/ProjectQuestionsNewPage/edit.css";
-import ErrorAlert from "@/src/components/common/ErrorAlert";
-import { Loading } from "@/src/components/common/Loading";
 
 export default function ProjectQuestionsNewPage() {
   const { projectId } = useParams();
@@ -35,23 +32,23 @@ export default function ProjectQuestionsNewPage() {
     params: [resolvedProjectId],
   });
 
-
   const progressStepOptions = progressStepData
-  ? progressStepData.map((step) => ({
-      id: step.id, // key 값
-      title: step.name, // 사용자에게 보이는 텍스트
-      value: String(step.id), // select 요소에서 사용할 값
-    }))
-  : [];
+    ? progressStepData.map((step) => ({
+        id: step.id, // key 값
+        title: step.name, // 사용자에게 보이는 텍스트
+        value: String(step.id), // select 요소에서 사용할 값
+      }))
+    : [];
 
-  const [progressStepId, setProgressStepId] = useState<number | undefined>(undefined);
+  const [progressStepId, setProgressStepId] = useState<number | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
-      if (progressStepOptions.length > 0 && progressStepId === undefined) {
-        setProgressStepId(progressStepOptions[0].id);
-      }
-    }, [progressStepOptions]);
-  
+    if (progressStepOptions.length > 0 && progressStepId === undefined) {
+      setProgressStepId(progressStepOptions[0].id);
+    }
+  }, [progressStepOptions]);
 
   const handleSave = async <T extends QuestionRequestData>(requestData: T) => {
     try {
@@ -69,7 +66,6 @@ export default function ProjectQuestionsNewPage() {
     }
   };
 
-
   return (
     <Box
       maxW="1000px"
@@ -83,8 +79,12 @@ export default function ProjectQuestionsNewPage() {
     >
       <BackButton />
 
-      <ArticleForm title={title} setTitle={setTitle} handleSave={handleSave} progressStepId={progressStepId ?? 0}>
-       
+      <ArticleForm
+        title={title}
+        setTitle={setTitle}
+        handleSave={handleSave}
+        progressStepId={progressStepId ?? 0}
+      >
         <FormSelectInput
           label="진행 단계"
           selectedValue={progressStepId}

--- a/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
@@ -129,21 +129,21 @@ export default function ProjectsManagementStepCards({
       mb="2rem"
       width="full"
       mx="auto"
-      border={`1px solid ${borderColor}`}
-      borderRadius="lg"
-      boxShadow="md"
       bg={bgColor}
-      p={4}
+      transition="all 0.3s ease-in-out"
     >
-      <Heading size="xl" color={textColor} mb="16px" textAlign="left">
+      <Heading size="2xl" color={textColor} mb="10px" textAlign="left">
         {title}
       </Heading>
       <Flex
         wrap="nowrap"
         justifyContent="center"
         alignItems="center"
-        gap={8}
+        p={4}
+        border={`1px solid ${borderColor}`}
         borderRadius="lg"
+        boxShadow="md"
+        gap={8}
         bg={bgColor}
       >
         {mappedData.map((item) => {

--- a/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { JSX, useState } from "react";
+import { Box, Flex, Heading } from "@chakra-ui/react";
+import {
+  OctagonPause,
+  PackageCheck,
+  Signature,
+  Swords,
+  Wrench,
+} from "lucide-react";
+import ProjectsManagementStepCard from "@/src/components/pages/ProjectWorkFlowPage/components/ProjectsManagementStepCard";
+import { useColorModeValue } from "@/src/components/ui/color-mode";
+import { ProjectManagementSteps } from "@/src/constants/projectManagementSteps";
+import ConfirmDialog from "@/src/components/common/ConfirmDialog";
+import { projectManagementStepApi } from "@/src/api/projects";
+import { useParams } from "next/navigation";
+import { showToast } from "@/src/utils/showToast";
+import { useProjectInfoContext } from "@/src/context/ProjectInfoContext";
+
+const icons: Partial<Record<ProjectManagementSteps, JSX.Element>> = {
+  [ProjectManagementSteps.CONTRACT]: <Signature size="60%" />,
+  [ProjectManagementSteps.IN_PROGRESS]: <Swords size="60%" />,
+  [ProjectManagementSteps.COMPLETED]: <PackageCheck size="60%" />,
+  [ProjectManagementSteps.MAINTENANCE]: <Wrench size="60%" />,
+  [ProjectManagementSteps.PAUSED]: <OctagonPause size="60%" />,
+};
+
+interface ProjectsManagementStepCardsProps {
+  title: string;
+}
+
+export default function ProjectsManagementStepCards({
+  title,
+}: ProjectsManagementStepCardsProps) {
+  const { projectId } = useParams();
+
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const [selectedStep, setSelectedStep] = useState<string>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const bgColor = useColorModeValue("white", "gray.800");
+  const borderColor = useColorModeValue("gray.200", "gray.700");
+  const textColor = useColorModeValue("gray.700", "gray.200");
+
+  const { data, refetch } = useProjectInfoContext();
+  const currentManagementStep = data?.managementStep; // 현재 프로젝트 단계
+
+  const mappedData = [
+    {
+      id: 1,
+      label: "계약",
+      step: ProjectManagementSteps.CONTRACT,
+    },
+    {
+      id: 2,
+      label: "진행중",
+      step: ProjectManagementSteps.IN_PROGRESS,
+    },
+    {
+      id: 3,
+      label: "납품완료",
+      step: ProjectManagementSteps.COMPLETED,
+    },
+    {
+      id: 4,
+      label: "하자보수",
+      step: ProjectManagementSteps.MAINTENANCE,
+    },
+    {
+      id: 5,
+      label: "일시중단",
+      step: ProjectManagementSteps.PAUSED,
+    },
+  ];
+
+  const handleStepClick = (managementStep: string) => {
+    if (managementStep === currentManagementStep) {
+      showToast({
+        title: "현재와 같은 단계입니다.",
+        description: "이미 해당 프로젝트 관리 단계에 있습니다.",
+        type: "info",
+      });
+      return;
+    }
+    setSelectedStep(managementStep);
+    setIsConfirmDialogOpen(true);
+  };
+
+  const handleConfirmNavigation = async () => {
+    if (!selectedStep) return;
+
+    setIsLoading(true);
+    try {
+      await projectManagementStepApi(projectId as string, selectedStep);
+
+      // selectedStep을 한글 라벨로 변환
+      const selectedStepLabel =
+        mappedData.find((item) => item.step === selectedStep)?.label ||
+        selectedStep;
+
+      showToast({
+        title: "관리단계 변경 성공",
+        description: `프로젝트 관리 단계가 ${selectedStepLabel}로 변경되었습니다.`,
+        type: "success",
+      });
+
+      // 리렌더링을 위해 데이터 다시 가져오기
+      await refetch();
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.message ||
+        error.message ||
+        "데이터를 불러오는데 실패했습니다.";
+      showToast({
+        title: "관리단계 변경 실패",
+        description: "변경 중 오류가 발생했습니다.",
+        type: "error",
+        error: errorMessage,
+      });
+    } finally {
+      setIsLoading(false);
+      setIsConfirmDialogOpen(false);
+    }
+  };
+
+  return (
+    <Box
+      mb="2rem"
+      width="full"
+      mx="auto"
+      border={`1px solid ${borderColor}`}
+      borderRadius="lg"
+      boxShadow="md"
+      bg={bgColor}
+      p={4}
+    >
+      <Heading size="xl" color={textColor} mb="16px" textAlign="left">
+        {title}
+      </Heading>
+      <Flex
+        wrap="nowrap"
+        justifyContent="center"
+        alignItems="center"
+        gap={8}
+        borderRadius="lg"
+        bg={bgColor}
+      >
+        {mappedData.map((item) => {
+          const isCurrentStep = item.step === currentManagementStep;
+
+          return (
+            <ProjectsManagementStepCard
+              key={item.id}
+              label={item.label}
+              icon={icons[item.step]}
+              managementStep={item.step}
+              onClick={
+                isCurrentStep ? () => {} : () => handleStepClick(item.step)
+              }
+              isSelected={isCurrentStep}
+              isDisabled={isCurrentStep} // 비활성화된 경우 클릭, hover 제거
+            />
+          );
+        })}
+      </Flex>
+      <ConfirmDialog
+        isOpen={isConfirmDialogOpen}
+        onClose={() => setIsConfirmDialogOpen(false)}
+        onConfirm={handleConfirmNavigation}
+        title="프로젝트 관리단계 변경"
+        description=""
+        confirmText="확인"
+        cancelText="취소"
+        isLoading={isLoading}
+      />
+    </Box>
+  );
+}

--- a/src/components/pages/ProjectWorkFlowPage/components/ProjectsManagementStepCard.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/ProjectsManagementStepCard.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from "react";
+import { Box, Flex, Text, useBreakpointValue } from "@chakra-ui/react";
+import { useColorModeValue } from "@/src/components/ui/color-mode";
+import { ProjectManagementSteps } from "@/src/constants/projectManagementSteps"; // ENUM import
+
+interface ProjectsManagementStepCardProps {
+  label: string; // 카드에 표시될 라벨
+  icon: ReactNode; // 카드 내부 아이콘
+  managementStep: ProjectManagementSteps; // 필터링할 상태 값
+  onClick: () => void;
+  isSelected: boolean; // 선택 여부
+  isDisabled?: boolean; // 비활성화 여부
+}
+
+/**
+ * ManagementStepCard 컴포넌트
+ * - 프로젝트 관리 단계 카드 UI
+ */
+export default function ProjectsManagementStepCard({
+  label,
+  icon,
+  onClick,
+  isSelected,
+  isDisabled = false,
+}: ProjectsManagementStepCardProps) {
+  // 반응형 크기 설정
+  const cardWidth = useBreakpointValue({
+    base: "100px", // 모바일
+    sm: "130px", // 작은 태블릿
+    md: "180px", // 데스크탑
+  });
+
+  const cardHeight = useBreakpointValue({
+    base: "100px",
+    sm: "120px",
+    md: "140px",
+  });
+
+  const iconSize = useBreakpointValue({
+    base: "2rem", // 모바일
+    sm: "2.5rem", // 작은 태블릿
+    md: "3rem", // 데스크탑
+  });
+
+  // 다크모드 색상 설정
+  const borderColor = useColorModeValue("gray.200", "gray.600");
+  const textColor = useColorModeValue("gray.700", "gray.700");
+  const hoverBgColor = useColorModeValue("gray.100", "gray.600");
+  const selectedBgColor = useColorModeValue("blue.100", "blue.900");
+
+  return (
+    <Box
+      background={isSelected ? selectedBgColor : "white"}
+      width={cardWidth}
+      height={cardHeight}
+      border={`1px solid ${borderColor}`}
+      borderRadius="lg"
+      boxShadow="sm"
+      padding={3}
+      transition="all 0.3s ease"
+      _hover={
+        !isDisabled
+          ? { backgroundColor: hoverBgColor, transform: "scale(1.05)" }
+          : undefined
+      }
+      cursor={isDisabled ? "not-allowed" : "pointer"}
+      onClick={isDisabled ? undefined : onClick} // 클릭 방지
+    >
+      <Flex alignItems="center" height="100%" gap={3}>
+        <Flex
+          border={`1px solid ${borderColor}`}
+          borderRadius="full"
+          overflow="hidden"
+          alignItems="center"
+          justifyContent="center"
+          w={iconSize}
+          h={iconSize}
+        >
+          {icon}
+        </Flex>
+        <Flex
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+        >
+          {/* 줄 바꿈 방지 및 글자 생략 적용 */}
+          <Text
+            fontSize="md"
+            fontWeight={500}
+            color={textColor}
+            maxWidth="100px" // 글자 최대 너비 설정
+            whiteSpace="nowrap" // 줄 바꿈 방지
+            overflow="hidden"
+            textOverflow="ellipsis" // 너무 길면 "..."
+            textAlign="center"
+          >
+            {label}
+          </Text>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/pages/ProjectWorkFlowPage/index.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/index.tsx
@@ -1,17 +1,17 @@
 "use client";
 
+import { useParams } from "next/navigation";
 import { ProjectLayout } from "@/src/components/layouts/ProjectLayout";
-import GuideButton from "@/src/components/common/GuideButton";
+import ProjectsManagementStepCards from "@/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards";
+import { ProjectInfoProvider } from "@/src/context/ProjectInfoContext";
 
 export default function ProjectWorkFlowPage() {
+  const { projectId } = useParams();
   return (
-    <ProjectLayout>
-      프로젝트 진척관리 페이지
-      <GuideButton
-        label="도움말"
-        guideText="* 이 페이지는 추후 개발이 진행될 예정입니다. 참고 부탁드립니다"
-        position={{ top: "20%", right: "20%" }}
-      />
-    </ProjectLayout>
+    <ProjectInfoProvider projectId={projectId as string}>
+      <ProjectLayout>
+        <ProjectsManagementStepCards title={"관리 단계 변경"} />
+      </ProjectLayout>
+    </ProjectInfoProvider>
   );
 }

--- a/src/components/pages/ProjectWorkFlowPage/index.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/index.tsx
@@ -1,17 +1,106 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { Heading, Table } from "@chakra-ui/react";
 import { ProjectLayout } from "@/src/components/layouts/ProjectLayout";
 import ProjectsManagementStepCards from "@/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards";
-import { ProjectInfoProvider } from "@/src/context/ProjectInfoContext";
+import { useColorModeValue } from "@/src/components/ui/color-mode";
+import CommonTable from "@/src/components/common/CommonTable";
+import { useProjectList } from "@/src/hook/useFetchBoardList";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
+import { useUserInfo } from "@/src/hook/useFetchData";
+import StatusTag from "@/src/components/common/StatusTag";
 
 export default function ProjectWorkFlowPage() {
-  const { projectId } = useParams();
+  const textColor = useColorModeValue("gray.700", "gray.200");
+
+  // 현재 로그인 한 사용자 정보
+  const { data: loggedInUserInfo } = useUserInfo();
+  const userRole = loggedInUserInfo?.role; // 기본값 설정
+
+  // const {
+  //   data: projectList,
+  //   loading: projectListLoading,
+  //   error: projectListError,
+  // } = useProjectList(keyword, managementStep, currentPage, pageSize);
+
   return (
-    <ProjectInfoProvider projectId={projectId as string}>
+    <>
       <ProjectLayout>
         <ProjectsManagementStepCards title={"관리 단계 변경"} />
       </ProjectLayout>
-    </ProjectInfoProvider>
+      <Heading size="2xl" color={textColor} lineHeight="base">
+        진행단계 요약
+      </Heading>
+      {/* {projectListError && (
+        <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+      )}
+      {/*
+       * 공통 테이블(CommonTable)
+       *  - headerTitle: 테이블 헤더 구성
+       *  - data: 테이블에 표시될 데이터
+       *  - loading: 로딩 상태
+       *  - renderRow: 한 줄씩 어떻게 렌더링할지 정의 (jsx 반환)
+       *  - handleRowClick: 행 클릭 이벤트 핸들러
+       */}
+
+      {/* <CommonTable
+        headerTitle={
+          <Table.Row
+            backgroundColor={useColorModeValue("#eee", "gray.700")}
+            css={{
+              "& > th": { textAlign: "center" },
+            }}
+          >
+            <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
+            <Table.ColumnHeader>고객사</Table.ColumnHeader>
+            <Table.ColumnHeader>개발사</Table.ColumnHeader>
+            <Table.ColumnHeader>관리단계</Table.ColumnHeader>
+            <Table.ColumnHeader>시작일</Table.ColumnHeader>
+            <Table.ColumnHeader>예정 마감일</Table.ColumnHeader>
+            <Table.ColumnHeader>납품 완료일</Table.ColumnHeader>
+            {userRole === "ADMIN" ? (
+              <>
+                <Table.ColumnHeader>수정일</Table.ColumnHeader>
+                <Table.ColumnHeader>삭제여부</Table.ColumnHeader>
+                <Table.ColumnHeader>공지사항관리</Table.ColumnHeader>
+              </>
+            ) : (
+              <></>
+            )}
+          </Table.Row>
+        }
+        data={projectList}
+        loading={projectListLoading}
+        renderRow={(project) => (
+          <>
+            <Table.Cell>{project.name}</Table.Cell>
+            <Table.Cell>{project.customerName}</Table.Cell>
+            <Table.Cell>{project.developerName}</Table.Cell>
+            <Table.Cell>
+              <StatusTag>
+                {STATUS_LABELS[project.managementStep] || "알 수 없음"}
+              </StatusTag>
+            </Table.Cell>
+            <Table.Cell>{formatDynamicDate(project.startAt)}</Table.Cell>
+            <Table.Cell>{formatDynamicDate(project.deadlineAt)}</Table.Cell>
+            <Table.Cell>{formatDynamicDate(project.closeAt)}</Table.Cell>
+            {userRole === "ADMIN" ? (
+              <>
+                <Table.Cell>{formatDynamicDate(project.updateAt)}</Table.Cell>
+                <Table.Cell>{project.deletedYn}</Table.Cell>
+                <Table.Cell
+                  onClick={(event) => event.stopPropagation()}
+                ></Table.Cell>
+              </>
+            ) : (
+              <></>
+            )}
+          </>
+        )}
+        handleRowClick={handleRowClick}
+        isClickable={(project) => project.clickable === 1}
+        placeholderHeight="300px" // 자리 표시자 높이
+      />  */}
+    </>
   );
 }

--- a/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
+++ b/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
@@ -29,13 +29,13 @@ const icons = [
   <OctagonX key="7" size="60%" color="black" />,
 ];
 
-interface ProjectsStatusCardsProps {
+interface ProjectsManagementStepCardsProps {
   title: string;
 }
 // 프로젝트 현황을 하나 보여주는 카드
-export default function ProjectsStatusCards({
+export default function ProjectsManagementStepCards({
   title,
-}: ProjectsStatusCardsProps) {
+}: ProjectsManagementStepCardsProps) {
   const {
     data: managementStepsCountData,
     loading: managementStepsCountLoading,

--- a/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
+++ b/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
@@ -118,9 +118,6 @@ export default function ProjectsManagementStepCards({
       width="full" // 전체 너비 사용
       mx="auto" // 가운데 정렬
       // maxWidth="var(--content-max-width)" // 공통 테이블과 같은 너비
-      border={`1px solid ${borderColor}`}
-      borderRadius="lg"
-      boxShadow="md"
       bg={bgColor} // 다크모드 배경색
       transition="all 0.3s ease-in-out"
     >
@@ -128,14 +125,13 @@ export default function ProjectsManagementStepCards({
       <Heading size="2xl" color={textColor} mb="10px" textAlign="left">
         {title}
       </Heading>
-
       {managementStepsCountError && (
         <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
       )}
       {/* 카드 컨테이너 */}
       <Flex
         wrap="nowrap"
-        justifyContent="space-between"
+        justifyContent="center"
         alignItems="center"
         gap={gap}
         p={4}

--- a/src/context/ProjectInfoContext.tsx
+++ b/src/context/ProjectInfoContext.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { createContext, useContext, ReactNode } from "react";
+import { useProjectInfo } from "@/src/hook/useFetchData";
+
+interface ProjectInfoContextProps {
+  data: any;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+const ProjectInfoContext = createContext<ProjectInfoContextProps | undefined>(
+  undefined,
+);
+
+export const ProjectInfoProvider = ({
+  projectId,
+  children,
+}: {
+  projectId: string;
+  children: ReactNode;
+}) => {
+  const { data, loading, error, refetch } = useProjectInfo(projectId);
+
+  return (
+    <ProjectInfoContext.Provider value={{ data, loading, error, refetch }}>
+      {children}
+    </ProjectInfoContext.Provider>
+  );
+};
+
+export const useProjectInfoContext = () => {
+  const context = useContext(ProjectInfoContext);
+  if (!context) {
+    throw new Error(
+      "useProjectInfoContext must be used within a ProjectInfoProvider",
+    );
+  }
+  return context;
+};

--- a/src/hook/useFetchData.ts
+++ b/src/hook/useFetchData.ts
@@ -55,34 +55,34 @@ export function useFetchData<T, P extends any[]>({
     fetchData(...params);
   }, [...params]);
 
-  return { data, loading, error };
+  return { data, loading, error, refetch: () => fetchData(...params) };
 }
 
 /**
  * 프로젝트 질문 Progress Step 데이터 패칭 훅
  */
-export const useProjectQuestionProgressStepData = (resolvedProjectId: string) =>
+export const useProjectQuestionProgressStepData = (projectId: string) =>
   useFetchData<ProjectProgressStepProps[], [string]>({
     fetchApi: fetchProjectQuestionProgressStepApi,
-    params: [resolvedProjectId],
+    params: [projectId],
   });
 
 /**
  * 프로젝트 정보 데이터 패칭 훅
  */
-export const useProjectInfo = (resolvedProjectId: string) =>
+export const useProjectInfo = (projectId: string) =>
   useFetchData<ProjectInfoProps, [string]>({
     fetchApi: fetchProjectInfoApi,
-    params: [resolvedProjectId],
+    params: [projectId],
   });
 
 /**
  * 결재 Progress Step 데이터 패칭 훅
  */
-export const useProjectApprovalProgressStepData = (resolvedProjectId: string) =>
+export const useProjectApprovalProgressStepData = (projectId: string) =>
   useFetchData<ProjectProgressStepProps[], [string]>({
     fetchApi: fetchProjectApprovalProgressStepApi,
-    params: [resolvedProjectId],
+    params: [projectId],
   });
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -110,17 +110,13 @@ async function validateAndRefreshTokens(
           return { userInfo: userInfoResponse.data, response };
         }
       } else {
+        console.warn("❌ Refresh Token 없음 → 로그인 페이지로 이동");
         return { response };
       }
     }
   } catch (error: any) {
     console.error("❌ Refresh Token 사용 중 오류 발생:", error.message);
     clearCookies(response);
-  }
-
-  if (!refreshToken) {
-    console.warn("❌ Refresh Token 없음 → 로그인 페이지로 이동");
-    return { response };
   }
 
   try {


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 진척관리게시판 관리단계 변경 기능 구현
- Related to #174

### 🔧 What has been changed?
- ProjectInfoContext를 통해 상태값 공유
- WorkFlow에 ProjectManagementStepCard와 ProjectManagementStepCards 컴포넌트 추가
- ProjectLayout에 관리단계 한글로 맵핑
- SearchSection Input값에 빈문자열 초기값 추가
- ConfirmDialog CSS 변경
- projects/[projectId]  하위 레이아웃에 ProjectInfoProvider 적용
- 미들웨어 분기처리 최적화

### 📸 Screenshots / GIFs (if applicable)

### ⚠️ Precaution & Known issues
진척관리게시판 진행단계 요약 테이블 구현 예정

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
