### PR TITLE
회원 목록 테이블 수정 및 삭제 버튼 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,7 +90,7 @@ button {
   @apply font-inherit cursor-pointer rounded-md border-none px-6 py-3;
   background-color: var(--button-bg, #e5e5e5);
   color: var(--button-text-color, #000);
-  padding: 2%;
+  padding: 0.5rem;
 }
 
 button:hover {

--- a/src/components/pages/AdminOrganizationsPage/index.tsx
+++ b/src/components/pages/AdminOrganizationsPage/index.tsx
@@ -122,7 +122,7 @@ function AdminOrganizationsPageContent() {
           </SearchSection>
         </Box>
         {organizationListError && (
-          <ErrorAlert message="공지사항 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+          <ErrorAlert message="업체 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
         <CommonTable
           headerTitle={
@@ -139,6 +139,7 @@ function AdminOrganizationsPageContent() {
               <Table.ColumnHeader>주소</Table.ColumnHeader>
               <Table.ColumnHeader>상태</Table.ColumnHeader>
               <Table.ColumnHeader>등록일</Table.ColumnHeader>
+              <Table.ColumnHeader>관리</Table.ColumnHeader>
             </Table.Row>
           }
           data={organizationList ?? []}


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 회원 목록 테이블 수정 및 삭제 버튼 구현
- Related to #184 

### 🔧 What has been changed?

- 회원 목록 테이블 우측 끝에 수정 및 삭제 버튼 UI 추가
- `수정 버튼` 클릭 시 수정 페이지로 이동
- `삭제 버튼` 클릭 시 삭제 완료 (버튼 스위치 클릭 불가)

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
