### PR TITLE
업체 목록 수정, 삭제 버튼 추가

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -92,7 +92,7 @@ export async function updateOrganization(
   return response.data;
 }
 
-// 📌 회원 삭제 (탈퇴 사유 포함 ver.)
+// 📌 업체 삭제 (탈퇴 사유 포함 ver.)
 export async function deleteOriginationWithReason(
   organizationId: string,
   reason: string,

--- a/src/components/layouts/SidebarTab.tsx
+++ b/src/components/layouts/SidebarTab.tsx
@@ -33,6 +33,13 @@ const ADMIN_MENU_ITEMS = [
   { value: "/notices", title: "공지사항 관리", icon: Bell },
 ];
 
+// 고객사/개발사 메뉴 항목
+const MEMBER_MENU_ITEMS = [
+  // { value: "/", title: "홈", icon: Briefcase },
+  { value: "/", title: "홈", icon: Home },
+  { value: "/notices", title: "공지사항", icon: Bell },
+];
+
 export default function SidebarTab({ memberRole }: SidebarTabProps) {
   const bgColor = useColorModeValue("white", "gray.900");
   const hoverBgColor = useColorModeValue("gray.100", "gray.700");
@@ -91,6 +98,25 @@ export default function SidebarTab({ memberRole }: SidebarTabProps) {
         </Box>
       ) : (
         <>
+          <Box mb={6} borderBottom="1px solid" borderColor={borderColor}>
+            {MEMBER_MENU_ITEMS.map((item) => (
+              <Link key={item.value} href={item.value}>
+                <Box
+                  p={4}
+                  display="flex"
+                  alignItems="center"
+                  gap={3}
+                  borderBottom="1px solid"
+                  borderColor={borderColor}
+                  _hover={{ bg: hoverBgColor }}
+                >
+                  {item.icon && <item.icon size={20} />}{" "}
+                  {/* 선택적으로 아이콘 삽입 */}
+                  {item.title}
+                </Box>
+              </Link>
+            ))}
+          </Box>
           <MenuRoot positioning={{ placement: "bottom-start" }}>
             <MenuTrigger asChild>
               <Box

--- a/src/components/pages/AdminMembersPage/index.tsx
+++ b/src/components/pages/AdminMembersPage/index.tsx
@@ -24,7 +24,7 @@ import {
   deleteMember,
 } from "@/src/api/members";
 import { MemberProps } from "@/src/types";
-import DropDownMenu from "../../common/DropDownMenu";
+import DropDownMenu from "@/src/components/common/DropDownMenu";
 
 const memberRoleFramework = createListCollection<{
   label: string;

--- a/src/components/pages/AdminOrganizationsPage/index.tsx
+++ b/src/components/pages/AdminOrganizationsPage/index.tsx
@@ -18,6 +18,8 @@ import SearchSection from "@/src/components/common/SearchSection";
 import FilterSelectBox from "@/src/components/common/FilterSelectBox";
 import { formatDynamicDate } from "@/src/utils/formatDateUtil";
 import ErrorAlert from "@/src/components/common/ErrorAlert";
+import DropDownMenu from "@/src/components/common/DropDownMenu";
+import { deleteOriginationWithReason } from "@/src/api/organizations";
 
 const organizationTypeFramework = createListCollection<{
   label: string;
@@ -94,6 +96,22 @@ function AdminOrganizationsPageContent() {
     router.push(`/admin/organizations/${id}`);
   };
 
+  const handleEdit = (id: string) => {
+    router.push(`/admin/organizations/${id}`);
+  };
+
+  const handleDelete = async (id: string) => {
+    const confirmDelete = window.confirm("정말로 삭제하시겠습니까?");
+    if (!confirmDelete) return;
+    try {
+      await deleteOriginationWithReason(id, "");
+      alert("업체가 삭제 조치 되었습니다.");
+      router.refresh();
+    } catch (error) {
+      alert(`삭제 중 문제가 발생했습니다 : ${error}`);
+    }
+  };
+
   return (
     <>
       <Stack width="full">
@@ -154,19 +172,21 @@ function AdminOrganizationsPageContent() {
                 "& > td": { textAlign: "center" },
               }}
             >
-              <Table.Cell>
-                {TYPE_LABELS[organization.type] || "알 수 없음"}
-              </Table.Cell>
+              <Table.Cell>{TYPE_LABELS[organization.type]}</Table.Cell>
               <Table.Cell>{organization.name}</Table.Cell>
               <Table.Cell>{organization.brNumber}</Table.Cell>
               <Table.Cell>{organization.phoneNumber}</Table.Cell>
               <Table.Cell>{`${organization.streetAddress} ${organization.detailAddress}`}</Table.Cell>
               <Table.Cell>
-                <StatusTag>
-                  {STATUS_LABELS[organization.status] || "알 수 없음"}
-                </StatusTag>
+                <StatusTag>{STATUS_LABELS[organization.status]}</StatusTag>
               </Table.Cell>
               <Table.Cell>{formatDynamicDate(organization.regAt)}</Table.Cell>
+              <Table.Cell onClick={(event) => event.stopPropagation()}>
+                <DropDownMenu
+                  onEdit={() => handleEdit(organization.id)}
+                  onDelete={() => handleDelete(organization.id)}
+                />
+              </Table.Cell>
             </Table.Row>
           )}
         />

--- a/src/hook/useFetchBoardList.ts
+++ b/src/hook/useFetchBoardList.ts
@@ -1,6 +1,20 @@
 import { useEffect, useState } from "react";
-import { CommonResponseWithMetaType, PaginationProps, ProjectQuestionListResponse, ProjectApprovalListResponse, ProjectListResponse, NoticeListResponse, OrganizationListResponse, MemberListResponse } from "@/src/types";
-import { fetchProjectQuestionListApi, fetchProjectApprovalListApi, fetchProjectListApi, projectProgressStepApi } from "@/src/api/projects";
+import {
+  CommonResponseWithMetaType,
+  PaginationProps,
+  ProjectQuestionListResponse,
+  ProjectApprovalListResponse,
+  ProjectListResponse,
+  NoticeListResponse,
+  OrganizationListResponse,
+  MemberListResponse,
+} from "@/src/types";
+import {
+  fetchProjectQuestionListApi,
+  fetchProjectApprovalListApi,
+  fetchProjectListApi,
+  projectProgressStepApi,
+} from "@/src/api/projects";
 import { showToast } from "@/src/utils/showToast";
 import { fetchNoticeListApi } from "@/src/api/notices";
 import { fetchOrganizationListApi } from "@/src/api/organizations";
@@ -42,8 +56,11 @@ export function useFetchBoardList<T, P extends any[], K extends keyof T>({
     } catch (err: any) {
       console.error("Error fetching data:", err);
       // ✅ 서버 응답에서 message 필드가 있는 경우 해당 메시지 사용
-      const errorMessage = err.response?.data?.message || err.message || "데이터를 불러오는 중 오류가 발생했습니다.";
-      
+      const errorMessage =
+        err.response?.data?.message ||
+        err.message ||
+        "데이터를 불러오는 중 오류가 발생했습니다.";
+
       // ✅ 토스트로 사용자에게 알림
       showToast({
         title: "요청 실패",
@@ -62,7 +79,13 @@ export function useFetchBoardList<T, P extends any[], K extends keyof T>({
     fetchBoardListData(...params);
   }, [...params]);
 
-  return { data, paginationInfo, loading, error, refetch: () => fetchBoardListData(...params) };
+  return {
+    data,
+    paginationInfo,
+    loading,
+    error,
+    refetch: () => fetchBoardListData(...params),
+  };
 }
 
 // ProjectQuestionList 데이터 패칭
@@ -72,23 +95,24 @@ export const useProjectQuestionList = (
   progressStep: string,
   status: string,
   currentPage: number,
-  pageSize: number
-) => useFetchBoardList<
-  ProjectQuestionListResponse,
-  [string, string, string, string, number, number],
-  "projectQuestions"
->({
-  fetchApi: fetchProjectQuestionListApi,
-  keySelector: "projectQuestions",
-  params: [
-    resolvedProjectId,
-    keyword,
-    progressStep,
-    status,
-    currentPage,
-    pageSize,
-  ],
-});
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    ProjectQuestionListResponse,
+    [string, string, string, string, number, number],
+    "projectQuestions"
+  >({
+    fetchApi: fetchProjectQuestionListApi,
+    keySelector: "projectQuestions",
+    params: [
+      resolvedProjectId,
+      keyword,
+      progressStep,
+      status,
+      currentPage,
+      pageSize,
+    ],
+  });
 
 // ProjectTaskList 데이터 패칭
 export const useProjectApprovalList = (
@@ -97,39 +121,41 @@ export const useProjectApprovalList = (
   progressStep: string,
   status: string,
   currentPage: number,
-  pageSize: number
-) => useFetchBoardList<
-  ProjectApprovalListResponse,
-  [string, string, string, string, number, number],
-  "projectApprovals"
->({
-  fetchApi: fetchProjectApprovalListApi,
-  keySelector: "projectApprovals",
-  params: [
-    resolvedProjectId,
-    keyword,
-    progressStep,
-    status,
-    currentPage,
-    pageSize,
-  ],
-});
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    ProjectApprovalListResponse,
+    [string, string, string, string, number, number],
+    "projectApprovals"
+  >({
+    fetchApi: fetchProjectApprovalListApi,
+    keySelector: "projectApprovals",
+    params: [
+      resolvedProjectId,
+      keyword,
+      progressStep,
+      status,
+      currentPage,
+      pageSize,
+    ],
+  });
 
 // 프로젝트 목록 패칭
 export const useProjectList = (
   keyword: string,
   status: string,
   currentPage: number,
-  pageSize: number
-) => useFetchBoardList<
-ProjectListResponse,
-[string, string, number, number],
-"projects"
->({
-fetchApi: fetchProjectListApi,
-keySelector: "projects",
-params: [keyword, status, currentPage, pageSize],
-});
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    ProjectListResponse,
+    [string, string, number, number],
+    "projects"
+  >({
+    fetchApi: fetchProjectListApi,
+    keySelector: "projects",
+    params: [keyword, status, currentPage, pageSize],
+  });
 
 // 공지사항 목록 패칭
 export const useNoticeList = (
@@ -137,16 +163,17 @@ export const useNoticeList = (
   category: string,
   isDeleted: string,
   currentPage: number,
-  pageSize: number
-) => useFetchBoardList<
-NoticeListResponse,
-[string, string, string, number, number],
-"notices"
->({
-fetchApi: fetchNoticeListApi,
-keySelector: "notices",
-params: [keyword, category, isDeleted, currentPage, pageSize],
-});
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    NoticeListResponse,
+    [string, string, string, number, number],
+    "notices"
+  >({
+    fetchApi: fetchNoticeListApi,
+    keySelector: "notices",
+    params: [keyword, category, isDeleted, currentPage, pageSize],
+  });
 
 // 회원 목록 패칭
 export const useMemberList = (
@@ -154,9 +181,9 @@ export const useMemberList = (
   role: string,
   status: string,
   currentPage: number,
-  pageSize: number
-) => 
-useFetchBoardList<
+  pageSize: number,
+) =>
+  useFetchBoardList<
     MemberListResponse,
     [string, string, string, number, number],
     "members"
@@ -172,9 +199,9 @@ export const useOrganizationList = (
   type: string,
   status: string,
   currentPage: number,
-  pageSize: number
-) => 
-useFetchBoardList<
+  pageSize: number,
+) =>
+  useFetchBoardList<
     OrganizationListResponse,
     [string, string, string, number, number],
     "dtoList"


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 업체 목록 수정, 삭제 버튼 추가
- Related to #189 

### 🔧 What has been changed?

- 1) 업체 목록 수정, 삭제 버튼 추가
- 2) 고객사/개발사 사이드바 메뉴에 `홈` 과 `공지사항` 추가
 
### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
