### PR TITLE
업체 활성화/비활성화 토글 기능 추가

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -107,3 +107,13 @@ export async function deleteOriginationWithReason(
     throw error; // 🚨 에러 발생 시 throw
   }
 }
+
+export async function changeOrganizationStatusApi(
+  organizationId: string,
+): Promise<CommonResponseType<OrganizationProps>> {
+    const response = await axiosInstance.post(
+      `/admins/organizations/${organizationId}/changeStatus`,
+    );
+
+    return response.data;
+}

--- a/src/components/common/ArticleContent.tsx
+++ b/src/components/common/ArticleContent.tsx
@@ -8,18 +8,15 @@ import {
   ArticleLink,
   ArticleFile,
   ContentBlock,
-  NoticeArticle,
 } from "@/src/types";
 import { formatDateWithTime } from "@/src/utils/formatDateUtil";
 
-interface ArticleContentProps<
-  T extends QuestionArticle | ApprovalArticle | NoticeArticle,
-> {
+interface ArticleContentProps<T extends QuestionArticle | ApprovalArticle> {
   article: T | null;
 }
 
 export default function ArticleContent<
-  T extends QuestionArticle | ApprovalArticle | NoticeArticle,
+  T extends QuestionArticle | ApprovalArticle,
 >({ article }: ArticleContentProps<T>) {
   if (!article) {
     return (

--- a/src/components/common/CommonTable.tsx
+++ b/src/components/common/CommonTable.tsx
@@ -5,6 +5,7 @@ import { Box, Table } from "@chakra-ui/react";
 import { SkeletonText } from "@/src/components/ui/skeleton";
 
 interface CommonTableProps<T> {
+  columnsWidth?: ReactNode;
   headerTitle: ReactNode;
   data: T[] | null;
   loading: boolean;
@@ -12,6 +13,7 @@ interface CommonTableProps<T> {
 }
 
 export default function CommonTable<T extends { id: string }>({
+  columnsWidth,
   headerTitle,
   data = [],
   loading,
@@ -39,22 +41,14 @@ export default function CommonTable<T extends { id: string }>({
         maxWidth="none" // 너비 제한 없음
         css={{
           borderCollapse: "collapse",
-          // "& th, & td": { border: "1.8px solid #ddd", padding: "8px" },
-          "& th, & td": { padding: "8px" },
-          "& th": { padding: "16px" },
+          tableLayout: "fixed",
+          "& th, & td": { padding: "0.5rem" },
+          "& th": { padding: "1rem" },
         }}
       >
-        {/* 테이블 헤더 */}
-        <Table.Header
-          css={{
-            "& th": {
-              textAlign: "center",
-              fontWeight: "bold",
-            },
-          }}
-        >
-          {headerTitle}
-        </Table.Header>
+        <Table.ColumnGroup>{columnsWidth}</Table.ColumnGroup>
+
+        <Table.Header>{headerTitle}</Table.Header>
 
         {/* 테이블 바디 */}
         <Table.Body>

--- a/src/components/common/FilterSelectBox.tsx
+++ b/src/components/common/FilterSelectBox.tsx
@@ -10,8 +10,9 @@ import {
 
 interface StatusSelectBoxProps {
   statusFramework: ReturnType<typeof createListCollection>;
-  selectedValue: string;
+  selectedValue: string | undefined;
   queryKey: string;
+  placeholder: string;
   width?: string;
 }
 
@@ -24,6 +25,7 @@ export default function FilterSelectBox({
   statusFramework,
   selectedValue,
   queryKey,
+  placeholder,
   width = "110px",
 }: StatusSelectBoxProps) {
   const router = useRouter();
@@ -61,13 +63,17 @@ export default function FilterSelectBox({
       collection={statusFramework}
       size="md"
       width={width}
-      value={[selectedValue]}
+      value={selectedValue ? [selectedValue] : []}
       onValueChange={handleValueChange}
     >
       {/* 드롭다운 버튼(트리거) */}
       <SelectTrigger>
         {/* 선택된 값이 표시될 영역 */}
-        <SelectValueText textAlign="center" width="100%" />
+        <SelectValueText
+          textAlign="center"
+          width="100%"
+          placeholder={placeholder}
+        />
       </SelectTrigger>
 
       {/* 드롭다운 펼쳤을 때의 옵션 목록 */}

--- a/src/components/pages/AdminMembersPage/index.tsx
+++ b/src/components/pages/AdminMembersPage/index.tsx
@@ -9,6 +9,7 @@ import {
   Heading,
   Stack,
   Table,
+  Text,
 } from "@chakra-ui/react";
 import { Switch } from "@/src/components/ui/switch";
 import CommonTable from "@/src/components/common/CommonTable";
@@ -52,12 +53,6 @@ const memberStatusFramework = createListCollection<{
 const ROLE_LABELS: Record<string, string> = {
   ADMIN: "관리자",
   MEMBER: "일반회원",
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  ACTIVE: "활성화",
-  INACTIVE: "비활성화",
-  DELETED: "삭제됨",
 };
 
 // const renderStatusSwitch = (status: string) => {
@@ -132,7 +127,7 @@ function AdminMembersPageContent() {
       console.error("회원 상태 변경 실패:", error);
       alert("회원 상태 변경 중 오류가 발생했습니다.");
     } finally {
-      setLoadingId(null); // ✅ 로딩 해제
+      setLoadingId(null); // 로딩 해제
     }
   };
 
@@ -196,11 +191,13 @@ function AdminMembersPageContent() {
               statusFramework={memberRoleFramework}
               selectedValue={role}
               queryKey="role"
+              placeholder="역할"
             />
             <FilterSelectBox
               statusFramework={memberStatusFramework}
               selectedValue={status}
               queryKey="status"
+              placeholder="활성화 여부"
             />
           </SearchSection>
         </Box>
@@ -248,7 +245,7 @@ function AdminMembersPageContent() {
               <Table.Cell>{member.phoneNum}</Table.Cell>
               <Table.Cell onClick={(event) => event.stopPropagation()}>
                 {member.status === "DELETED" ? (
-                  <Switch disabled />
+                  <Text color="red">삭제됨</Text>
                 ) : (
                   <Switch
                     checked={member.status === "ACTIVE"}

--- a/src/components/pages/AdminOrganizationsPage/index.tsx
+++ b/src/components/pages/AdminOrganizationsPage/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Box,
@@ -9,8 +9,9 @@ import {
   Heading,
   Stack,
   Table,
+  Text,
 } from "@chakra-ui/react";
-import StatusTag from "@/src/components/common/StatusTag";
+import { Switch } from "@/src/components/ui/switch";
 import CommonTable from "@/src/components/common/CommonTable";
 import Pagination from "@/src/components/common/Pagination";
 import { useOrganizationList } from "@/src/hook/useFetchBoardList";
@@ -20,6 +21,7 @@ import { formatDynamicDate } from "@/src/utils/formatDateUtil";
 import ErrorAlert from "@/src/components/common/ErrorAlert";
 import DropDownMenu from "@/src/components/common/DropDownMenu";
 import { deleteOriginationWithReason } from "@/src/api/organizations";
+import { useUpdateOrganizationStatus } from "@/src/hook/useMutationData";
 
 const organizationTypeFramework = createListCollection<{
   label: string;
@@ -48,11 +50,6 @@ const TYPE_LABELS: Record<string, string> = {
   DEVELOPER: "개발사",
 };
 
-const STATUS_LABELS: Record<string, string> = {
-  ACTIVE: "활성화",
-  INACTIVE: "비활성화",
-};
-
 export default function AdminOrganizationsPage() {
   return (
     <Suspense>
@@ -76,7 +73,24 @@ function AdminOrganizationsPageContent() {
     paginationInfo,
     loading: organizationListLoading,
     error: organizationListError,
+    refetch,
   } = useOrganizationList(keyword, type, status, currentPage, pageSize);
+
+  const [loadingId, setLoadingId] = useState<string | null>(null); // 특정 업체의 Switch 로딩 상태
+
+  // 업체 상태 변경 훅
+  const { mutate: updateOrganizationStatus } = useUpdateOrganizationStatus();
+
+  // 업체 상태 변경 핸들러
+  const handleStatusChange = async (organizationId: string) => {
+    setLoadingId(organizationId);
+    try {
+      await updateOrganizationStatus(organizationId);
+      refetch();
+    } finally {
+      setLoadingId(null);
+    }
+  };
 
   // 신규등록 버튼 클릭 시 - 업체 등록 페이지로 이동
   const handleMemberCreateButton = () => {
@@ -131,11 +145,13 @@ function AdminOrganizationsPageContent() {
               statusFramework={organizationTypeFramework}
               selectedValue={type}
               queryKey="type"
+              placeholder="업체유형"
             />
             <FilterSelectBox
               statusFramework={OrganizationStatusFramework}
               selectedValue={status}
               queryKey="status"
+              placeholder="활성화 여부"
             />
           </SearchSection>
         </Box>
@@ -143,6 +159,18 @@ function AdminOrganizationsPageContent() {
           <ErrorAlert message="업체 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
         <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="8%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="30%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="8%" />
+              <Table.Column htmlWidth="6%" />
+            </>
+          }
           headerTitle={
             <Table.Row
               backgroundColor={"#eee"}
@@ -169,16 +197,34 @@ function AdminOrganizationsPageContent() {
               css={{
                 cursor: "pointer",
                 "&:hover": { backgroundColor: "#f5f5f5" },
-                "& > td": { textAlign: "center" },
+                "& > td": {
+                  textAlign: "center",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                },
               }}
             >
               <Table.Cell>{TYPE_LABELS[organization.type]}</Table.Cell>
               <Table.Cell>{organization.name}</Table.Cell>
               <Table.Cell>{organization.brNumber}</Table.Cell>
               <Table.Cell>{organization.phoneNumber}</Table.Cell>
-              <Table.Cell>{`${organization.streetAddress} ${organization.detailAddress}`}</Table.Cell>
               <Table.Cell>
-                <StatusTag>{STATUS_LABELS[organization.status]}</StatusTag>
+                {`${organization.streetAddress} ${organization.detailAddress}`}
+              </Table.Cell>
+              <Table.Cell onClick={(event) => event.stopPropagation()}>
+                {organization.status === "DELETED" ? (
+                  <Text color="red">삭제됨</Text>
+                ) : (
+                  <Switch
+                    checked={organization.status === "ACTIVE"}
+                    onChange={(event) => {
+                      event.stopPropagation();
+                      handleStatusChange(organization.id);
+                    }}
+                    disabled={loadingId === organization.id} // ✅ 상태 변경 시 로딩 적용
+                  />
+                )}
               </Table.Cell>
               <Table.Cell>{formatDynamicDate(organization.regAt)}</Table.Cell>
               <Table.Cell onClick={(event) => event.stopPropagation()}>

--- a/src/components/pages/NoticeEditPage/index.tsx
+++ b/src/components/pages/NoticeEditPage/index.tsx
@@ -101,7 +101,6 @@ export default function NoticeEditPage() {
           progressStepId={1} // 임시
           initialTitle={notice.title || ""}
           initialContent={notice.content || []}
-          initialLinkList={notice.linkList || []}
           initialUploadedFiles={notice.fileList || []}
           title={notice.title || ""}
           setTitle={(value) =>

--- a/src/components/pages/NoticePage/components/NoticeArticleContent.tsx
+++ b/src/components/pages/NoticePage/components/NoticeArticleContent.tsx
@@ -2,25 +2,16 @@
 import { Box, Text, Image, VStack, Separator } from "@chakra-ui/react";
 
 // 절대 경로 파일
-import {
-  QuestionArticle,
-  ApprovalArticle,
-  ArticleLink,
-  ArticleFile,
-  ContentBlock,
-  NoticeArticle,
-} from "@/src/types";
+import { ArticleFile, ContentBlock, NoticeArticle } from "@/src/types";
 import { formatDateWithTime } from "@/src/utils/formatDateUtil";
 
-interface ArticleContentProps<
-  T extends QuestionArticle | ApprovalArticle | NoticeArticle,
-> {
+interface ArticleContentProps<T extends NoticeArticle> {
   article: T | null;
 }
 
-export default function ArticleContent<
-  T extends QuestionArticle | ApprovalArticle | NoticeArticle,
->({ article }: ArticleContentProps<T>) {
+export default function ArticleContent<T extends NoticeArticle>({
+  article,
+}: ArticleContentProps<T>) {
   if (!article) {
     return (
       <Box>
@@ -65,29 +56,6 @@ export default function ArticleContent<
     });
   };
 
-  // 링크 렌더링
-  const renderLinks = (links: ArticleLink[]) => {
-    return links.map((link, index) => {
-      const url =
-        link.url.startsWith("http://") || link.url.startsWith("https://")
-          ? link.url
-          : `https://${link.url}`;
-
-      return (
-        <Box
-          key={index}
-          mb={2}
-          cursor="pointer"
-          color={"blue"}
-          onClick={() => window.open(url, "_blank")}
-          _hover={{ textDecoration: "underline" }}
-        >
-          <Text fontWeight="normal">{link.name}</Text>
-        </Box>
-      );
-    });
-  };
-
   // 첨부파일 렌더링
   const renderFiles = (files: ArticleFile[]) => {
     if (!files || files.length === 0) {
@@ -121,8 +89,6 @@ export default function ArticleContent<
     });
   };
 
-  // regAt 날짜 예쁘게 변환
-
   return (
     <Box
       mb={4}
@@ -135,9 +101,7 @@ export default function ArticleContent<
         {article.title}
       </Text>
 
-      {/* 작성자, 작성 일시 (NoticeArticle인 경우 작성자 정보 숨김) */}
       <Box mb={4}>
-        {"author" in article && <Text>작성자: {article.author}</Text>}
         <Text>{formatDateWithTime(article.regAt)}</Text>
       </Box>
 

--- a/src/components/pages/NoticePage/index.tsx
+++ b/src/components/pages/NoticePage/index.tsx
@@ -32,7 +32,7 @@ export default function NoticePage() {
   const { mutate: deleteNotice } = useDeleteNotice();
 
   const isNoticeDeleted = noticeArticle?.isDeleted === "Y";
-  console.log(isNoticeDeleted);
+
   if (noticeLoading) {
     return <Loading />; // ✅ 공통 로딩 컴포넌트 사용
   }
@@ -46,11 +46,8 @@ export default function NoticePage() {
     if (!confirmDelete) return;
     try {
       await deleteNotice(noticeId);
-      alert("공지사항이 삭제되었습니다.");
       router.push(`/notices?currentPage=${currentPage}`);
-    } catch (error) {
-      alert(`삭제 중 문제가 발생했습니다 : ${error}`);
-    }
+    } catch (error) {}
   };
 
   return (

--- a/src/components/pages/NoticesPage/index.tsx
+++ b/src/components/pages/NoticesPage/index.tsx
@@ -142,6 +142,7 @@ function NoticesPageContent() {
               statusFramework={noticeStatusFramework}
               selectedValue={category}
               queryKey="category"
+              placeholder="카테고리"
               width="120px"
             />
           </SearchSection>
@@ -154,6 +155,7 @@ function NoticesPageContent() {
               statusFramework={noticeStatusFramework}
               selectedValue={category}
               queryKey="category"
+              placeholder="카테고리"
               width="120px"
             />
           </SearchSection>
@@ -183,6 +185,7 @@ function NoticesPageContent() {
                       statusFramework={noticeIsDeletedFramework}
                       selectedValue={isDeleted}
                       queryKey="isDeleted"
+                      placeholder="삭제여부"
                       width="150px"
                     />
                   </Flex>

--- a/src/components/pages/ProjectApprovalsPage/index.tsx
+++ b/src/components/pages/ProjectApprovalsPage/index.tsx
@@ -131,6 +131,7 @@ export default function ProjectApprovalsPage() {
           {/* 검색 섹션 */}
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <StatusSelectBox
+              placeholder="결재상태"
               statusFramework={approvalStatusFramework}
               selectedValue={status}
               queryKey="status"

--- a/src/components/pages/ProjectQuestionsPage/index.tsx
+++ b/src/components/pages/ProjectQuestionsPage/index.tsx
@@ -126,6 +126,7 @@ export default function ProjectQuestionsPage() {
           {/* 검색 섹션 */}
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <FilterSelectBox
+              placeholder="질문상태"
               statusFramework={questionStatusFramework}
               selectedValue={status}
               queryKey="status"

--- a/src/components/pages/ProjectsPage/components/ProjectsManagementStepCard.tsx
+++ b/src/components/pages/ProjectsPage/components/ProjectsManagementStepCard.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import { useRouter } from "next/navigation";
 import { Box, Flex, Text, useBreakpointValue } from "@chakra-ui/react";
 import { useColorModeValue } from "@/src/components/ui/color-mode";
 import { ProjectManagementSteps } from "@/src/constants/projectManagementSteps"; // ENUM import
@@ -8,7 +7,8 @@ interface ProjectsManagementStepCardProps {
   count: number; // 숫자(통계 수치)
   label: string; // 카드에 표시될 라벨
   icon: ReactNode; // 카드 내부 아이콘
-  managementStep: ProjectManagementSteps; // 필터링할 상태 값
+  isSelected?: boolean;
+  onClick: () => void;
 }
 
 /**
@@ -23,9 +23,9 @@ export default function ProjectsManagementStepCard({
   count,
   label,
   icon,
-  managementStep,
+  isSelected = false,
+  onClick,
 }: ProjectsManagementStepCardProps) {
-  const router = useRouter();
   // 반응형 크기 설정
   const cardWidth = useBreakpointValue({
     base: "100px", // 모바일
@@ -62,22 +62,9 @@ export default function ProjectsManagementStepCard({
   const textColor = useColorModeValue("gray.700", "gray.700");
   const hoverBgColor = useColorModeValue("gray.100", "gray.600");
 
-  // 클릭 시 필터 적용
-  const handleFilterClick = () => {
-    const params = new URLSearchParams(window.location.search);
-    params.set("currentPage", "1"); // 페이지를 1로 초기화
-    if (managementStep !== ProjectManagementSteps.ALL) {
-      params.set("managementStep", managementStep);
-    } else {
-      params.delete("managementStep"); // "전체" 선택 시 status 제거
-    }
-    router.push(`?${params.toString()}`);
-  };
-  // http://localhost:3000/?status=CONTRACT&currentPage=1
-
   return (
     <Box
-      background="white"
+      background={isSelected ? "blue.100" : "white"}
       width={cardWidth}
       height={cardHeight}
       border={`1px solid ${borderColor}`}
@@ -90,7 +77,7 @@ export default function ProjectsManagementStepCard({
         cursor: "pointer",
         transform: "scale(1.05)", // 살짝 확대 효과
       }}
-      onClick={handleFilterClick} // 클릭 시 필터 적용
+      onClick={onClick} // 클릭 시 필터 적용
     >
       <Flex alignItems="center" height="100%" gap={3}>
         <Flex

--- a/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
+++ b/src/components/pages/ProjectsPage/components/ProjectsManagementStepCards.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Box, Flex, Heading, useBreakpointValue } from "@chakra-ui/react";
 import {
   Folder,
@@ -36,6 +38,12 @@ interface ProjectsManagementStepCardsProps {
 export default function ProjectsManagementStepCards({
   title,
 }: ProjectsManagementStepCardsProps) {
+  const router = useRouter();
+  // 현재 선택된 관리 단계 상태
+  const [selectedStep, setSelectedStep] = useState<ProjectManagementSteps>(
+    ProjectManagementSteps.ALL,
+  );
+
   const {
     data: managementStepsCountData,
     loading: managementStepsCountLoading,
@@ -53,6 +61,18 @@ export default function ProjectsManagementStepCards({
   const bgColor = useColorModeValue("white", "gray.800");
   const borderColor = useColorModeValue("gray.200", "gray.700");
   const textColor = useColorModeValue("gray.700", "gray.200");
+
+  const handleStepClick = (step: ProjectManagementSteps) => {
+    setSelectedStep(step);
+    const params = new URLSearchParams(window.location.search);
+    params.set("currentPage", "1");
+    if (step !== ProjectManagementSteps.ALL) {
+      params.set("managementStep", step);
+    } else {
+      params.delete("managementStep");
+    }
+    router.push(`?${params.toString()}`);
+  };
 
   // 백엔드에서 받은 데이터
   const managementStepCountMap =
@@ -148,7 +168,8 @@ export default function ProjectsManagementStepCards({
             count={item.count}
             label={item.label}
             icon={item.icon}
-            managementStep={item.managementStepValue} // 필터링할 상태 값 추가
+            isSelected={selectedStep === item.managementStepValue}
+            onClick={() => handleStepClick(item.managementStepValue)}
           />
         ))}
       </Flex>

--- a/src/components/pages/ProjectsPage/index.tsx
+++ b/src/components/pages/ProjectsPage/index.tsx
@@ -159,6 +159,7 @@ function ProjectsPageContent() {
                 {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
                 <SearchSection keyword={keyword} placeholder="제목 입력">
                   <FilterSelectBox
+                    placeholder="관리단계"
                     statusFramework={projectStatusFramework}
                     selectedValue={managementStep}
                     queryKey="managementStep"
@@ -170,6 +171,7 @@ function ProjectsPageContent() {
                 {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
                 <SearchSection keyword={keyword} placeholder="프로젝트명 입력">
                   <FilterSelectBox
+                    placeholder="관리단계"
                     statusFramework={projectStatusFramework}
                     selectedValue={managementStep}
                     queryKey="managementStep"

--- a/src/hook/useMutationData.ts
+++ b/src/hook/useMutationData.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { showToast } from "@/src/utils/showToast";
-import { CommonResponseType, NoticeRequestData, ProgressStep } from "@/src/types";
+import { CommonResponseType, NoticeRequestData, OrganizationProps, ProgressStep } from "@/src/types";
 import { createNoticeApi, deleteNoticeApi, editNoticeApi } from "@/src/api/notices";
 import { updateProjectProgressStepApi } from "@/src/api/projects";
+import { changeOrganizationStatusApi } from "@/src/api/organizations";
 
 interface UseMutationDataProps<T, P extends any[]> {
   mutationApi: (...args: P) => Promise<CommonResponseType<T>>;
@@ -84,4 +85,13 @@ export function useUpdateProjectProgressStep() {
   return useMutationData<ProgressStep, [string, string, { startAt: string; deadlineAt: string }]>({
     mutationApi: updateProjectProgressStepApi,
   });
+}
+
+/**
+ * 조직 상태 변경 훅
+ */
+export function useUpdateOrganizationStatus() {
+  return useMutationData<OrganizationProps, [string]> ({
+    mutationApi: changeOrganizationStatusApi,
+  })
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -448,7 +448,6 @@ export interface NoticeArticle {
   regAt: string;
   updatedAt: string;
   fileList: ArticleFile[];
-  linkList: ArticleLink[];
 }
 
 // 게시글 첨부링크


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : 업체 활성화/비활성화 토글 기능 추가
- Related to #194 

### 🔧 What has been changed?

- 업체 활성화/비활성화 토글 기능 추가
- selectBox 가시성 올리기 위해 placeholder사용
- 프로젝트 현황판 현재 필터링 요소 색깔 지정

### 📸 Screenshots / GIFs (if applicable)
![image](https://github.com/user-attachments/assets/39207326-e424-4373-ac47-f107307c78db)
![image](https://github.com/user-attachments/assets/e4c4bd82-da7a-4a51-8a44-728553ccae0c)

### ⚠️ Precaution & Known issues

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
