### PR TITLE
[FEATURE] 업체 별 소속회원 및 참여 프로젝트 목록 조회 기능 구현

### DIFF
--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -10,7 +10,14 @@ import {
   MemberProps,
 } from "@/src/types";
 
-// 📌 회원 목록 Fetch API
+/**
+ * 회원 전체 목록을 가져옵니다.
+ * @param keyword 검색어 (기본값: "")
+ * @param filter 필터링 값 (기본값: "")
+ * @param currentPage 현재 페이지 번호
+ * @param pageSize 페이지 크기
+ * @returns 회원 목록 및 페이징 정보를 담은 객체
+ */
 export async function fetchMemberListApi(
   keyword: string = "", // 검색키워드
   role: string = "", // 계정타입
@@ -21,6 +28,32 @@ export async function fetchMemberListApi(
   const response = await axiosInstance.get("/admins/members", {
     params: { keyword, role, status, currentPage, pageSize },
   });
+
+  return response.data;
+}
+
+/**
+ * 업체 별 소속 회원 전체 목록을 가져옵니다.
+ * @param keyword 검색어 (기본값: "")
+ * @param filter 필터링 값 (기본값: "")
+ * @param currentPage 현재 페이지 번호
+ * @param pageSize 페이지 크기
+ * @returns 회원 목록 및 페이징 정보를 담은 객체
+ */
+export async function fetchOrganizationMemberListApi(
+  organizationId: string,
+  keyword: string = "", // 검색키워드
+  role: string = "", // 계정타입
+  status: string = "", // 활성화여부
+  currentPage: number,
+  pageSize: number,
+): Promise<CommonResponseType<MemberListResponse>> {
+  const response = await axiosInstance.get(
+    `/admins/members/member/org/${organizationId}`,
+    {
+      params: { organizationId, keyword, role, status, currentPage, pageSize },
+    },
+  );
 
   return response.data;
 }

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -11,6 +11,7 @@ import {
   ProjectInfoProps,
   ProgressStep,
   ManagementStepCountMap,
+  OrganizationProjectListResponse,
 } from "@/src/types";
 
 
@@ -90,6 +91,68 @@ export async function fetchProjectListApi(
   const response = await axiosInstance.get("/projects", {
     params: { keyword, managementStep, currentPage, pageSize },
   });
+
+  return response.data;
+}
+
+/**
+ * 업체 별 참여 중 프로젝트 목록을 가져옵니다.
+ * @param keyword 검색어 (기본값: "")
+ * @param filter 필터링 값 (기본값: "")
+ * @param currentPage 현재 페이지 번호
+ * @param pageSize 페이지 크기
+ * @returns 프로젝트 목록 및 페이징 정보를 담은 객체(BoardResponseProps)
+ */
+export async function fetchOrganizationProjectListApi(
+  organizationId: string,
+  keyword: string = "",
+  managementStep: string = "",
+  currentPage: number,
+  pageSize: number,
+): Promise<CommonResponseType<OrganizationProjectListResponse>> {
+  const response = await axiosInstance.get(
+    `/admins/organizations/${organizationId}/projects`,
+    {
+      params: {
+        organizationId,
+        keyword,
+        managementStep,
+        currentPage,
+        pageSize,
+      },
+    },
+  );
+
+  return response.data;
+}
+
+/**
+ * 회원 별 참여 중 프로젝트 목록을 가져옵니다.
+ * @param keyword 검색어 (기본값: "")
+ * @param filter 필터링 값 (기본값: "")
+ * @param currentPage 현재 페이지 번호
+ * @param pageSize 페이지 크기
+ * @returns 프로젝트 목록 및 페이징 정보를 담은 객체(BoardResponseProps)
+ */
+export async function fetchMemberProjectListApi(
+  memberId: string,
+  keyword: string = "",
+  managementStep: string = "",
+  currentPage: number,
+  pageSize: number,
+): Promise<CommonResponseType<OrganizationProjectListResponse>> {
+  const response = await axiosInstance.get(
+    `/admins/members/${memberId}/projects`,
+    {
+      params: {
+        memberId,
+        keyword,
+        managementStep,
+        currentPage,
+        pageSize,
+      },
+    },
+  );
 
   return response.data;
 }
@@ -271,11 +334,11 @@ export async function fetchProjectApprovalListApi(
 export async function updateProjectProgressStepApi(
   projectId: string,
   progressStepId: string,
-  requestData: { startAt: string; deadlineAt: string }
+  requestData: { startAt: string; deadlineAt: string },
 ): Promise<CommonResponseType<ProgressStep>> {
-    const response = await axiosInstance.put(
-      `/projects/${projectId}/progress-steps/${progressStepId}/plans`,
-      requestData
-    );
-    return response.data;
+  const response = await axiosInstance.put(
+    `/projects/${projectId}/progress-steps/${progressStepId}/plans`,
+    requestData,
+  );
+  return response.data;
 }

--- a/src/app/(dashboard)/admin/members/[memberId]/edit/page.tsx
+++ b/src/app/(dashboard)/admin/members/[memberId]/edit/page.tsx
@@ -1,3 +1,0 @@
-import AdminMemberEditPage from "@/src/components/pages/AdminMemberEditPage";
-
-export default AdminMemberEditPage;

--- a/src/app/(dashboard)/admin/organizations/[organizationId]/edit/page.tsx
+++ b/src/app/(dashboard)/admin/organizations/[organizationId]/edit/page.tsx
@@ -1,3 +1,0 @@
-import AdminOrganizationEditPage from "@/src/components/pages/AdminOrganizationEditPage";
-
-export default AdminOrganizationEditPage;

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -19,7 +19,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   const sidebarWidth = useBreakpointValue({
     base: isSidebarOpen ? "70vw" : "0",
-    md: isSidebarOpen ? "250px" : "0",
+    md: isSidebarOpen ? "10vw" : "0",
   });
 
   // 다크모드 색상 설정
@@ -80,9 +80,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <Box
             flex={1}
             bg={marginBgColor} // 마진 영역의 배경색 설정
-            // marginX={{ base: "0", md: isSidebarOpen ? "2%" : "10%" }} // 작은 화면에서는 마진 제거
             transition="margin 0.3s ease-in-out"
-            padding={4}
+            paddingY="1rem"
+            paddingX="2rem"
+            overflowY="auto"
           >
             <Flex
               as="main"
@@ -94,11 +95,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               // padding={4}
               bg={bgColor}
             >
-              <Box
-                width="100%"
-                maxWidth="var(--content-max-width)"
-                bg={bgColor}
-              >
+              <Box maxWidth="var(--content-max-width)" bg={bgColor}>
                 {children}
               </Box>
             </Flex>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-/* 글로벌 스타일 */
+/* 📌 글로벌 스타일 - 라이트 모드 전용 */
 :root {
   --header-height: 4rem;
   --sidebar-width-mobile: 0px;
@@ -7,67 +7,24 @@
   --font-size-base: 1rem;
   --font-size-sm: 0.875rem;
   --font-size-lg: 1.125rem;
-  --button-bg-light: #50c6ab;
-  --button-hover-bg-light: #21bdb4;
-  --button-active-bg-light: #01676e; /* 클릭 시 색상 */
-  --button-bg-dark: #6c757d;
-  --button-hover-bg-dark: #495057;
-  --button-active-bg-dark: #343a40;
-  --background-light: #f8f9fa;
-  --background-dark: #1a202c;
-  --text-light: #1a202c;
-  --text-dark: #f8f9fa;
+
+  /* ✅ 색상 통일 */
+  --primary-color: #007bff; /* 주요 버튼 색상 */
+  --primary-hover-color: #0056b3;
+  --primary-active-color: #003c80;
+  --background-color: #ffffff;
+  --text-color: #333;
+  --border-color: #ddd;
+  --input-bg: #f8f9fa;
+  --input-border: #6c757d;
+  --input-focus-border: var(--primary-color);
 }
 
 html {
   font-size: 16px;
 }
 
-@media (max-width: 1200px) {
-  html {
-    font-size: 13px;
-  }
-}
-
-@media (max-width: 768px) {
-  html {
-    font-size: 10px;
-  }
-}
-
-@media (max-width: 480px) {
-  html {
-    font-size: 7px;
-  }
-}
-
-/* Reset */
-/* * {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-} */
-
-/* 다크 모드 스타일 */
-body.light {
-  --background-color: var(--background-light);
-  --text-color: var(--text-light);
-  /* --button-bg: var(--button-bg-light); */
-  --button-hover-bg: var(--button-hover-bg-light);
-  --button-active-bg: var(--button-active-bg-light);
-}
-
-body.dark {
-  --background-color: var(--background-dark);
-  --text-color: var(--text-dark);
-  /* --button-bg: var(--button-bg-dark); */
-  --button-hover-bg: var(--button-hover-bg-dark);
-  --button-active-bg: var(--button-active-bg-dark);
-}
-
 body {
-  /* margin: 0;
-  padding: 0; */
   font-family: "Roboto", sans-serif;
   background-color: var(--background-color);
   color: var(--text-color);
@@ -83,100 +40,48 @@ a {
 }
 
 a:hover {
-  color: var(--button-hover-bg);
+  color: var(--primary-hover-color);
 }
 
+/* 📌 버튼 스타일 */
 button {
-  @apply font-inherit cursor-pointer rounded-md border-none px-6 py-3;
-  /* background-color: var(--button-bg-light); */
-  /* font-weight: bold; */
-  color: #000;
-  padding: 0.5rem;
-  transition: all 1s;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: var(--font-size-base);
+  color: #333;
+  transition: background-color 0.3s ease-in-out;
 }
 
 button:hover {
-  /* color: #323232; */
-  /* background-color: var(--button-hover-bg-light); */
+  background-color: var(--primary-hover-color);
 }
 
 /* 버튼 클릭 시 효과 */
 button:active {
-  background-color: var(--button-active-bg);
-  transform: scale(0.97);
+  background-color: var(--primary-active-color);
+  transform: scale(0.98);
 }
 
-/* 헤더 */
-header {
-  position: sticky;
-  top: 0;
-  width: 100%;
-  height: var(--header-height);
-  background-color: var(--background-light);
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 16px;
-  z-index: 10;
-}
-
-[data-theme="dark"] header {
-  background-color: var(--background-dark);
-}
-
-/* 반응형 사이드바 */
-.sidebar {
-  flex-basis: var(--sidebar-width); /* 기본 너비를 20%로 설정 */
-  min-width: 200px; /* 최소 너비 */
-  max-width: 250px; /* 최대 너비 */
-  background-color: var(--background-light);
-  border-right: 1px solid #ddd;
-  overflow-y: auto;
-  transition: all 0.3s ease-in-out;
-}
-
-[data-theme="dark"] .sidebar {
-  background-color: var(--background-dark);
-  border-color: #4a5568;
-}
-
-#root {
-  display: flex;
-  height: 100vh;
-  overflow: hidden;
-}
-
-main {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1rem;
-}
-
-/* 메인 콘텐츠 */
-.content {
-  flex: 1;
-  min-width: 0; /* Flexbox의 자식 요소가 올바르게 너비를 계산하도록 설정 */
-  max-width: var(--content-max-width);
-  overflow-x: auto;
-  padding: 1rem;
-}
-
+/* 📌 입력 필드 */
 .input {
   width: 100%;
   padding: 10px;
-  border: 1px solid #6c757d;
+  border: 1px solid var(--input-border);
   border-radius: 0.5rem;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
+  background-color: var(--input-bg);
   transition:
     background-color 0.3s,
     border 0.3s;
 }
 
 .input:focus {
-  border-color: var(--button-hover-bg);
+  border-color: var(--input-focus-border);
   outline: none;
-  box-shadow: 0 0 0 2px #01e4b3 (0, 123, 255, 0.2);
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.2);
 }
 
 .input.disabled {
@@ -185,13 +90,48 @@ main {
   cursor: not-allowed;
 }
 
-/* 수정된 필드 연한 초록색 강조 */
+/* 📌 수정된 필드 강조 (연한 파란색) */
 .input.changed {
-  background-color: #e8f5e9 !important;
-  border: 1px solid #01e4b3 !important;
+  background-color: #e3f2fd !important;
+  border: 1px solid var(--primary-color) !important;
 }
 
-/* 스크롤바 전체 */
+/* 📌 헤더 */
+header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: var(--header-height);
+  background-color: var(--background-color);
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  z-index: 10;
+}
+
+/* 반응형 사이드바 */
+.sidebar {
+  flex-basis: var(--sidebar-width); /* 기본 너비를 20%로 설정 */
+  min-width: 200px; /* 최소 너비 */
+  max-width: 250px; /* 최대 너비 */
+  background-color: var(--background-color);
+  border-right: 1px solid var(--border-color);
+  overflow-y: auto;
+  transition: all 0.3s ease-in-out;
+}
+
+/* 📌 메인 콘텐츠 */
+.content {
+  flex: 1;
+  min-width: 0;
+  max-width: var(--content-max-width);
+  overflow-x: auto;
+  padding: 1rem;
+}
+
+/* 📌 스크롤바 */
 ::-webkit-scrollbar {
   width: 8px; /* 세로 스크롤바 너비 */
   height: 5px; /* 가로 스크롤바 높이 */
@@ -214,13 +154,11 @@ main {
   background: #555;
 }
 
-/* 다크 모드 */
-[data-theme="dark"] ::-webkit-scrollbar-thumb {
-  background: #9b59b6;
-}
-
 /* 반응형 (태블릿 이하) */
-@media (max-width: 1024px) {
+@media (max-width: 1200px) {
+  html {
+    font-size: 13px;
+  }
   .sidebar {
     flex-basis: 250px; /* 태블릿에서는 고정된 너비 사용 */
     max-width: 250px;
@@ -229,6 +167,9 @@ main {
 
 /* 반응형 (모바일) */
 @media (max-width: 768px) {
+  html {
+    font-size: 10px;
+  }
   .sidebar {
     flex-basis: var(--sidebar-width-mobile); /* 모바일에서는 고정된 너비 사용 */
     transform: translateX(-100%);
@@ -244,5 +185,11 @@ main {
   .content {
     padding: 1rem;
     overflow-x: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  html {
+    font-size: 7px;
   }
 }

--- a/src/components/common/CommonTable.tsx
+++ b/src/components/common/CommonTable.tsx
@@ -47,14 +47,12 @@ export default function CommonTable<T extends { id: string }>({
         }}
       >
         <Table.ColumnGroup>{columnsWidth}</Table.ColumnGroup>
-
         <Table.Header>{headerTitle}</Table.Header>
-
         {/* 테이블 바디 */}
         <Table.Body>
           {loading ? (
             <Table.Row>
-              <Table.Cell colSpan={7} textAlign="center">
+              <Table.Cell colSpan={7}>
                 <SkeletonText noOfLines={5} gap="4" />
               </Table.Cell>
             </Table.Row>

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -98,7 +98,7 @@ export default function ConfirmDialog({
             onClick={onConfirm}
             loading={isLoading}
             loadingText="처리 중..."
-            colorScheme="blue"
+            // colorScheme="blue"
             disabled={isLoading}
             style={{
               width: "100%", // 버튼을 더 길게 설정

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -8,6 +8,8 @@ interface SearchSectionProps {
   keyword: string;
   placeholder?: string;
   children?: ReactNode;
+  keywordName?: string;
+  currentPageName?: string;
 }
 
 export default function SearchSection({

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { FiSun, FiMoon } from "react-icons/fi";
 import { Box, Flex, IconButton, Image, Text } from "@chakra-ui/react";
 import {
   useColorMode,
@@ -19,7 +18,7 @@ export default function Header({
   isSidebarOpen,
   onToggleSidebar,
 }: HeaderProps) {
-  const { toggleColorMode, colorMode } = useColorMode();
+  const { colorMode } = useColorMode();
   const textColor = useColorModeValue("gray.800", "white");
 
   return (
@@ -67,17 +66,8 @@ export default function Header({
         </Link>
       </Flex>
 
-      {/* 오른쪽: 다크모드 및 프로필 */}
-      <Flex align="center" gap="1rem">
-        <IconButton
-          aria-label="Toggle Dark Mode"
-          onClick={toggleColorMode}
-          variant="ghost"
-        >
-          {colorMode === "dark" ? <FiSun /> : <FiMoon />}
-        </IconButton>
-        <Profile />
-      </Flex>
+      {/* 오른쪽: 프로필 */}
+      <Profile />
     </Flex>
   );
 }

--- a/src/components/layouts/InputFormLayout.module.css
+++ b/src/components/layouts/InputFormLayout.module.css
@@ -1,11 +1,11 @@
 .container {
-  max-width: 80%;
+  max-width: 80vh;
 }
 
 .pageTitle {
   font-size: 24px;
   font-weight: bold;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 
 .buttonContainer {
@@ -16,17 +16,18 @@
   margin-top: 20px;
 }
 
-.submitButton {
-  background-color: #007bff;
+.submitButton,
+.deleteButton {
   color: white;
-  padding: 10px 15px;
+  padding: 0.5rem;
   border: none;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 1rem;
   border-radius: 5px;
-  transition:
-    background-color 0.3s,
-    opacity 0.3s;
+  transition: background-color 0.3s;
+}
+.submitButton {
+  background-color: #007bff;
 }
 /* 수정하기 버튼 활성화 상태 */
 .submitButton:hover {
@@ -34,9 +35,7 @@
 }
 /* 수정하기 버튼 비활성화 상태 */
 .submitButton:disabled {
-  background-color: #a0aec0; /* 회색 */
   cursor: not-allowed;
-  opacity: 0.5;
 }
 
 /* 수정하기 버튼 비활성화 상태에서는 hover 효과 제거 */
@@ -46,16 +45,8 @@
 
 .deleteButton {
   background-color: #dc3545;
-  color: white;
-  padding: 8px 12px;
-  border: none;
-  cursor: pointer;
-  font-size: 14px;
-  border-radius: 5px;
-  transition: background-color 0.3s;
-  right: 0; /* 수정하기 버튼 우측 끝에 배치 */
 }
 
 .deleteButton:hover {
-  background-color: #c82333;
+  background-color: #a0aec0;
 }

--- a/src/components/layouts/InputFormLayout.tsx
+++ b/src/components/layouts/InputFormLayout.tsx
@@ -14,7 +14,7 @@ import {
   DialogActionTrigger,
   DialogCloseTrigger,
 } from "@/src/components/ui/dialog"; // Chakra UI Dialog
-import { Button, Flex, Input, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Input, Text } from "@chakra-ui/react";
 import styles from "@/src/components/layouts/InputFormLayout.module.css";
 
 export default function InputFormLayout({
@@ -52,13 +52,15 @@ export default function InputFormLayout({
       <div className={styles.formWrapper}>
         <form onSubmit={onSubmit}>
           {/* 📌 페이지 타이틀 */}
-          <Flex justifyContent="space-between" alignItems="center">
-            <h1 className={styles.pageTitle} style={{ marginBottom: "0px" }}>
-              {title}
-            </h1>
-            <div className={styles.buttonContainer}>
+          <Flex
+            className={styles.pageTitle}
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <h1>{title}</h1>
+            <Box className={styles.buttonContainer}>
               {isDetailPage ? (
-                <>
+                <Flex gap="1rem">
                   {/* 수정 버튼 */}
                   <button
                     type="submit"
@@ -68,15 +70,15 @@ export default function InputFormLayout({
                     disabled={isLoading || isDisabled}
                     aria-busy={isLoading}
                   >
-                    {isLoading ? "처리 중..." : "수정하기"}
+                    {isLoading ? "처리 중..." : `${entityType} 수정`}
                   </button>
                   {/* 삭제 버튼 - 차크라 UI Dialog 컴포넌트 이용 */}
                   {onDelete && ( // 삭제 핸들러가 존재하는 경우만 표시
                     <DialogRoot role="alertdialog">
                       <DialogTrigger asChild>
-                        <Button className={styles.deleteButton}>
+                        <button className={styles.deleteButton}>
                           {entityType} 삭제
-                        </Button>
+                        </button>
                       </DialogTrigger>
                       <DialogContent>
                         <DialogHeader>
@@ -113,7 +115,7 @@ export default function InputFormLayout({
                       </DialogContent>
                     </DialogRoot>
                   )}
-                </>
+                </Flex>
               ) : (
                 /* 신규 등록 버튼 */
                 <button
@@ -127,7 +129,7 @@ export default function InputFormLayout({
                   {isLoading ? "처리 중..." : "등록하기"}
                 </button>
               )}
-            </div>
+            </Box>
           </Flex>
           {/* 📌 페이지 버튼 - 등록/수정/삭제 */}
           {/* 📌 페이지 입력폼 */}

--- a/src/components/pages/AdminMemberEditPage/index.tsx
+++ b/src/components/pages/AdminMemberEditPage/index.tsx
@@ -1,3 +1,0 @@
-export default function AdminMemberEditPage() {
-  return <div>AdminMemberEditPage</div>;
-}

--- a/src/components/pages/AdminMemberPage/components/MemberDetailForm.tsx
+++ b/src/components/pages/AdminMemberPage/components/MemberDetailForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import InputForm from "@/src/components/common/InputForm";
 import InputFormLayout from "@/src/components/layouts/InputFormLayout";
 import { MemberProps } from "@/src/types";
@@ -11,6 +11,47 @@ import {
   updateMember,
 } from "@/src/api/members";
 import { validationRulesOfUpdatingMember } from "@/src/constants/validationRules"; // 유효성 검사 규칙 import
+import {
+  Box,
+  createListCollection,
+  Flex,
+  Heading,
+  Stack,
+  Table,
+} from "@chakra-ui/react";
+import SearchSection from "@/src/components/common/SearchSection";
+import FilterSelectBox from "@/src/components/common/FilterSelectBox";
+import { useMemberProjectList } from "@/src/hook/useFetchBoardList";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
+import CommonTable from "@/src/components/common/CommonTable";
+import { useColorModeValue } from "@/src/components/ui/color-mode";
+import StatusTag from "@/src/components/common/StatusTag";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
+import Pagination from "@/src/components/common/Pagination";
+
+const projectStatusFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "계약", value: "CONTRACT" },
+    { label: "진행중", value: "IN_PROGRESS" },
+    { label: "납품완료", value: "COMPLETED" },
+    { label: "하자보수", value: "MAINTENANCE" },
+    { label: "일시중단", value: "PAUSED" },
+    { label: "삭제", value: "DELETED" },
+  ],
+});
+
+const STATUS_LABELS: Record<string, string> = {
+  CONTRACT: "계약",
+  IN_PROGRESS: "진행중",
+  COMPLETED: "납품완료",
+  MAINTENANCE: "하자보수",
+  PAUSED: "일시중단",
+  DELETED: "삭제",
+};
 
 export default function MemberDetailForm({
   memberData,
@@ -54,6 +95,7 @@ export default function MemberDetailForm({
     }
   }
 
+  // 📌 입력 값 유효성 검사
   function validateInputs() {
     // 🔹 `Object.entries()`를 사용하여 모든 필드에 대한 유효성 검사 수행
     const updatedErrors = Object.entries(
@@ -167,7 +209,7 @@ export default function MemberDetailForm({
   }
 
   return (
-    <>
+    <Flex direction="column" width="80vh" justifyContent="center" gap="1rem">
       <InputFormLayout
         title="▹ 회원 상세 조회"
         onSubmit={handleUpdate}
@@ -176,78 +218,259 @@ export default function MemberDetailForm({
         onDelete={handleDelete}
         deleteEntityType="회원" // 삭제 대상 선택 ("회원" | "업체" | "프로젝트")
       >
-        {/* 수정 불가 필드 */}
-        <InputForm
-          id="email"
-          type="email"
-          label="로그인 Email"
-          value={formData.email}
-          disabled
-        />
-        <InputForm
-          id="role"
-          type="text"
-          label="사용자 권한"
-          value={formData.role}
-          disabled
-        />
-
-        {/* 수정 가능 필드 */}
-        <InputForm
-          id="name"
-          type="text"
-          label="성함"
-          value={formData.name}
-          error={errors.name ?? undefined} // 에러 값이 null 이면 안돼서 undefined로 변환 (이하 동일)
-          onChange={(e) => handleInputUpdate("name", e.target.value)}
-          isChanged={!!isChanged["name"]}
-        />
-        <InputForm
-          id="phoneNum"
-          type="tel"
-          label="연락처"
-          value={formData.phoneNum}
-          error={errors.phoneNum ?? undefined}
-          onChange={(e) => handleInputUpdate("phoneNum", e.target.value)}
-          isChanged={!!isChanged["phoneNum"]}
-        />
-        <InputForm
-          id="jobRole"
-          type="text"
-          label="직무"
-          value={formData.jobRole}
-          error={errors.jobRole ?? undefined}
-          onChange={(e) => handleInputUpdate("jobRole", e.target.value)}
-          isChanged={!!isChanged["jobRole"]}
-        />
-        <InputForm
-          id="jobTitle"
-          type="text"
-          label="직함"
-          value={formData.jobTitle}
-          error={errors.jobTitle ?? undefined}
-          onChange={(e) => handleInputUpdate("jobTitle", e.target.value)}
-          isChanged={!!isChanged["jobTitle"]}
-        />
-        <InputForm
-          id="introduction"
-          type="text"
-          label="회원 소개"
-          value={formData.introduction}
-          error={errors.introduction ?? undefined}
-          onChange={(e) => handleInputUpdate("introduction", e.target.value)}
-          isChanged={!!isChanged["introduction"]}
-        />
-        <InputForm
-          id="remark"
-          type="text"
-          label="특이사항"
-          value={formData.remark}
-          error={errors.remark ?? undefined}
-          onChange={(e) => handleInputUpdate("remark", e.target.value)}
-          isChanged={!!isChanged["remark"]}
-        />
+        {/* 성함, 연락처 */}
+        <Flex gap={4} align="center">
+          <Box flex="2">
+            <InputForm
+              id="name"
+              type="text"
+              label="성함"
+              value={formData.name}
+              error={errors.name ?? undefined} // 에러 값이 null 이면 안돼서 undefined로 변환 (이하 동일)
+              onChange={(e) => handleInputUpdate("name", e.target.value)}
+              isChanged={!!isChanged["name"]}
+            />
+          </Box>
+          {/* (수정불가) 로그인 Email */}
+          <Box flex="2">
+            <InputForm
+              id="email"
+              type="email"
+              label="로그인 Email"
+              value={formData.email}
+              disabled
+            />
+          </Box>
+          {/* (수정불가) 사용자 권한 */}
+          <Box flex="1">
+            <InputForm
+              id="role"
+              type="text"
+              label="사용자 권한"
+              value={formData.role}
+              disabled
+            />
+          </Box>
+        </Flex>
+        {/* 연락처, 직무, 직함 */}
+        <Flex gap={4} align="center">
+          <Box flex="2">
+            <InputForm
+              id="phoneNum"
+              type="tel"
+              label="연락처"
+              value={formData.phoneNum}
+              error={errors.phoneNum ?? undefined}
+              onChange={(e) => handleInputUpdate("phoneNum", e.target.value)}
+              isChanged={!!isChanged["phoneNum"]}
+            />
+          </Box>
+          <Box flex="2">
+            <InputForm
+              id="jobRole"
+              type="text"
+              label="직무"
+              value={formData.jobRole}
+              error={errors.jobRole ?? undefined}
+              onChange={(e) => handleInputUpdate("jobRole", e.target.value)}
+              isChanged={!!isChanged["jobRole"]}
+            />
+          </Box>
+          <Box flex="1">
+            <InputForm
+              id="jobTitle"
+              type="text"
+              label="직함"
+              value={formData.jobTitle}
+              error={errors.jobTitle ?? undefined}
+              onChange={(e) => handleInputUpdate("jobTitle", e.target.value)}
+              isChanged={!!isChanged["jobTitle"]}
+            />
+          </Box>
+        </Flex>
+        {/* 직무, 직함 */}
+        <Flex gap={4} align="center">
+          <Box flex="1"></Box>
+        </Flex>
+        {/*회원 소개, 특이사항 */}
+        <Flex gap={4} align="center">
+          <Box flex="1">
+            <InputForm
+              id="introduction"
+              type="text"
+              label="회원 소개"
+              value={formData.introduction}
+              error={errors.introduction ?? undefined}
+              onChange={(e) =>
+                handleInputUpdate("introduction", e.target.value)
+              }
+              isChanged={!!isChanged["introduction"]}
+            />
+          </Box>
+          <Box flex="1">
+            <InputForm
+              id="remark"
+              type="text"
+              label="특이사항"
+              value={formData.remark}
+              error={errors.remark ?? undefined}
+              onChange={(e) => handleInputUpdate("remark", e.target.value)}
+              isChanged={!!isChanged["remark"]}
+            />
+          </Box>
+        </Flex>
       </InputFormLayout>
+      <Suspense>
+        {/* 회원 별 참여 중 프로젝트 목록 조회 */}
+        <MemberProjectList memberId={memberId} />
+      </Suspense>
+    </Flex>
+  );
+}
+
+// 회원 별 참여 중 프로젝트 목록 조회
+function MemberProjectList({ memberId }: { memberId: string }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const keyword = searchParams?.get("keyword") || "";
+  const managementStep = searchParams?.get("managementStep") || "";
+  const currentPage = parseInt(searchParams?.get("currentPage") || "1", 10);
+  const pageSize = parseInt(searchParams?.get("pageSize") || "10", 5);
+
+  const {
+    data: projectList,
+    paginationInfo,
+    loading: projectListLoading,
+    error: projectListError,
+  } = useMemberProjectList(
+    memberId,
+    keyword,
+    managementStep,
+    currentPage,
+    pageSize,
+  );
+
+  /**
+   * 페이지 변경 시 호출되는 콜백 함수
+   * - 쿼리 파라미터를 갱신하고, fetchProjectList를 다시 호출합니다.
+   *
+   * @param page 새로 이동할 페이지 번호
+   */
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(window.location.search);
+    // 쿼리스트링 업데이트
+    params.set("currentPage", page.toString());
+    // URL 업데이트
+    router.push(`?${params.toString()}`);
+  };
+
+  /**
+   * 테이블 행 클릭 시 호출되는 콜백
+   * - 특정 프로젝트의 상세 화면(/projects/[id]/tasks)로 이동
+   *
+   * @param projectId 프로젝트 ID (백엔드 혹은 테이블에서 받아온 값)
+   */
+  const handleRowClick = (projectId: string) => {
+    const project = projectList?.find((p) => p.id === projectId);
+    if (project) {
+      router.push(`/projects/${project.id}/questions`);
+    }
+  };
+
+  return (
+    <>
+      <Stack width="full">
+        <Heading size="2xl" color="gray.600">
+          프로젝트 목록
+        </Heading>
+        <Flex justifyContent="end">
+          {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
+          <SearchSection keyword={keyword} placeholder="프로젝트명 입력">
+            <FilterSelectBox
+              statusFramework={projectStatusFramework}
+              selectedValue={managementStep}
+              placeholder="관리단계 선택"
+              queryKey="managementStep"
+            />
+          </SearchSection>
+        </Flex>
+        {projectListError && (
+          <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
+        <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+            </>
+          }
+          headerTitle={
+            <Table.Row
+              backgroundColor={useColorModeValue("#eee", "gray.700")}
+              css={{
+                "& > th": { textAlign: "center" },
+              }}
+            >
+              <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
+              <Table.ColumnHeader>고객사</Table.ColumnHeader>
+              <Table.ColumnHeader>개발사</Table.ColumnHeader>
+              <Table.ColumnHeader>관리단계</Table.ColumnHeader>
+              <Table.ColumnHeader>시작일</Table.ColumnHeader>
+              <Table.ColumnHeader>예상 마감일</Table.ColumnHeader>
+              <Table.ColumnHeader>납품 완료일</Table.ColumnHeader>
+            </Table.Row>
+          }
+          data={projectList || []}
+          loading={projectListLoading}
+          renderRow={(project) => {
+            return (
+              <Table.Row
+                key={project.id}
+                onClick={() => handleRowClick(project.id)}
+                css={{
+                  "&:hover": { backgroundColor: "#f1f1f1" },
+                  cursor: "pointer",
+                  opacity: 1,
+                  "& > td": { textAlign: "center" },
+                }}
+              >
+                <Table.Cell>{project.name}</Table.Cell>
+                <Table.Cell>{project.customerName}</Table.Cell>
+                <Table.Cell>{project.developerName}</Table.Cell>
+                <Table.Cell>
+                  <StatusTag>{STATUS_LABELS[project.managementStep]}</StatusTag>
+                </Table.Cell>
+                <Table.Cell>{formatDynamicDate(project.startAt)}</Table.Cell>
+                <Table.Cell>{formatDynamicDate(project.deadlineAt)}</Table.Cell>
+                <Table.Cell>
+                  {formatDynamicDate(project.closeAt) === ""
+                    ? "-"
+                    : formatDynamicDate(project.closeAt)}
+                </Table.Cell>
+              </Table.Row>
+            );
+          }}
+        />
+        {/*
+         * 페이지네이션 컴포넌트
+         * paginationInfo: 현재 페이지, 총 페이지, 페이지 크기 등의 정보
+         * handlePageChange: 페이지 이동 시 실행될 콜백
+         */}
+        <Pagination
+          paginationInfo={
+            paginationInfo && {
+              ...paginationInfo,
+              currentPage: paginationInfo.currentPage,
+            }
+          }
+          handlePageChange={handlePageChange}
+        />
+      </Stack>
     </>
   );
 }

--- a/src/components/pages/AdminMembersPage/index.tsx
+++ b/src/components/pages/AdminMembersPage/index.tsx
@@ -205,6 +205,19 @@ function AdminMembersPageContent() {
           <ErrorAlert message="회원 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
         <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="20%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="5%" />
+              <Table.Column htmlWidth="5%" />
+            </>
+          }
           headerTitle={
             <Table.Row
               backgroundColor={"#eee"}
@@ -218,8 +231,8 @@ function AdminMembersPageContent() {
               <Table.ColumnHeader>직무 | 직책</Table.ColumnHeader>
               <Table.ColumnHeader>이메일</Table.ColumnHeader>
               <Table.ColumnHeader>연락처</Table.ColumnHeader>
-              <Table.ColumnHeader>상태</Table.ColumnHeader>
               <Table.ColumnHeader>등록일</Table.ColumnHeader>
+              <Table.ColumnHeader>상태</Table.ColumnHeader>
               <Table.ColumnHeader>관리</Table.ColumnHeader>
             </Table.Row>
           }
@@ -232,7 +245,12 @@ function AdminMembersPageContent() {
               css={{
                 cursor: "pointer",
                 "&:hover": { backgroundColor: "#f5f5f5" },
-                "& > td": { textAlign: "center" },
+                "& > td": {
+                  textAlign: "center",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                },
               }}
             >
               <Table.Cell>
@@ -243,6 +261,7 @@ function AdminMembersPageContent() {
               <Table.Cell>{`${member.jobRole} | ${member.jobTitle}`}</Table.Cell>
               <Table.Cell>{member.email}</Table.Cell>
               <Table.Cell>{member.phoneNum}</Table.Cell>
+              <Table.Cell>{formatDynamicDate(member.regAt)}</Table.Cell>
               <Table.Cell onClick={(event) => event.stopPropagation()}>
                 {member.status === "DELETED" ? (
                   <Text color="red">삭제됨</Text>
@@ -257,7 +276,6 @@ function AdminMembersPageContent() {
                   />
                 )}
               </Table.Cell>
-              <Table.Cell>{formatDynamicDate(member.regAt)}</Table.Cell>
               <Table.Cell onClick={(event) => event.stopPropagation()}>
                 <DropDownMenu
                   onEdit={() => handleEdit(member.id)}

--- a/src/components/pages/AdminOrganizationEditPage/index.tsx
+++ b/src/components/pages/AdminOrganizationEditPage/index.tsx
@@ -1,3 +1,0 @@
-export default function AdminOrganizationEditPage() {
-  return <div>AdminOrganizationEditPage</div>;
-}

--- a/src/components/pages/AdminOrganizationPage/components/organizationDetailForm.tsx
+++ b/src/components/pages/AdminOrganizationPage/components/organizationDetailForm.tsx
@@ -1,12 +1,23 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { Box, Flex, HStack } from "@chakra-ui/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  createListCollection,
+  Flex,
+  Heading,
+  HStack,
+  Stack,
+  Table,
+  Tabs,
+  useTabs,
+} from "@chakra-ui/react";
+import { Switch } from "@/src/components/ui/switch";
 import { Radio, RadioGroup } from "@/src/components/ui/radio";
 import InputForm from "@/src/components/common/InputForm";
 import InputFormLayout from "@/src/components/layouts/InputFormLayout";
-import { OrganizationProps } from "@/src/types";
+import { MemberProps, OrganizationProps } from "@/src/types";
 import {
   deleteOriginationWithReason,
   fetchOrganizationDetails,
@@ -14,6 +25,78 @@ import {
 } from "@/src/api/organizations";
 import styles from "@/src/components/common/InputForm.module.css";
 import { validationRulesOfUpdatingOrganization } from "@/src/constants/validationRules";
+import {
+  useOrganizationMemberList,
+  useOrganizationProjectList,
+} from "@/src/hook/useFetchBoardList";
+import SearchSection from "@/src/components/common/SearchSection";
+import FilterSelectBox from "@/src/components/common/FilterSelectBox";
+import ErrorAlert from "@/src/components/common/ErrorAlert";
+import CommonTable from "@/src/components/common/CommonTable";
+import StatusTag from "@/src/components/common/StatusTag";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
+import { useColorModeValue } from "@/src/components/ui/color-mode";
+import Pagination from "@/src/components/common/Pagination";
+import {
+  activateMemberApi,
+  deactivateMemberApi,
+  deleteMember,
+} from "@/src/api/members";
+import DropDownMenu from "@/src/components/common/DropDownMenu";
+import { SegmentedControl } from "@/src/components/ui/segmented-control";
+import { LuFolder, LuSquareCheck, LuUser } from "react-icons/lu";
+
+const memberRoleFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "관리자", value: "ADMIN" },
+    { label: "일반회원", value: "MEMBER" },
+  ],
+});
+
+const memberStatusFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "활성화", value: "ACTIVE" },
+    { label: "비활성화", value: "INACTIVE" },
+    { label: "삭제됨", value: "DELETED" },
+  ],
+});
+
+const ROLE_LABELS: Record<string, string> = {
+  ADMIN: "관리자",
+  MEMBER: "일반회원",
+};
+
+const projectStatusFramework = createListCollection<{
+  label: string;
+  value: string;
+}>({
+  items: [
+    { label: "전체", value: "" },
+    { label: "계약", value: "CONTRACT" },
+    { label: "진행중", value: "IN_PROGRESS" },
+    { label: "납품완료", value: "COMPLETED" },
+    { label: "하자보수", value: "MAINTENANCE" },
+    { label: "일시중단", value: "PAUSED" },
+    { label: "삭제", value: "DELETED" },
+  ],
+});
+
+const STATUS_LABELS: Record<string, string> = {
+  CONTRACT: "계약",
+  IN_PROGRESS: "진행중",
+  COMPLETED: "납품완료",
+  MAINTENANCE: "하자보수",
+  PAUSED: "일시중단",
+  DELETED: "삭제",
+};
 
 export default function OrganizationDetailForm({
   organizationData,
@@ -38,12 +121,16 @@ export default function OrganizationDetailForm({
     formData.brCertificateUrl.includes("|")
       ? formData.brCertificateUrl.split("|")
       : [null, null];
+  const tabs = useTabs({
+    defaultValue: "members",
+  });
 
   // 🔹 formData가 변경될 때만 실행되도록 설정
   useEffect(() => {
     validateInputs();
   }, [formData]);
 
+  // 첨부된 파일 불러오기
   useEffect(() => {
     return () => {
       if (
@@ -77,6 +164,7 @@ export default function OrganizationDetailForm({
     }
   }
 
+  // 📌 입력 값 유효성 검사
   function validateInputs() {
     // 🔹 `Object.entries()`를 사용하여 모든 필드에 대한 유효성 검사 수행
     const updatedErrors = Object.entries(
@@ -201,7 +289,7 @@ export default function OrganizationDetailForm({
   }
 
   return (
-    <>
+    <Flex direction="column" width="80vh" justifyContent="center" gap="1rem">
       <InputFormLayout
         title="▹ 업체 상세 조회"
         onSubmit={handleUpdate}
@@ -209,168 +297,626 @@ export default function OrganizationDetailForm({
         isDisabled={isUpdateDisabled} // 버튼 비활성화 조건 추가
         onDelete={handleDelete}
         deleteEntityType="업체" // 삭제 대상 선택 ("회원" | "업체" | "프로젝트")
-        
       >
-        {/* 수정 불가 필드 */}
-        <Box>
-          <Flex direction="row" align="center" mb={4}>
-            <span
-              style={{
-                fontSize: "14px",
-                fontWeight: "bold",
-                color: "#4A5568",
+        <Flex direction="column" gap="0.1rem">
+          {/* 수정 불가 필드 (업체 유형) */}
+          <Flex gap={4} align="center">
+            <Box>
+              <Flex direction="row" align="center" mb={4}>
+                <span
+                  style={{
+                    fontSize: "14px",
+                    fontWeight: "bold",
+                    color: "#4A5568",
+                  }}
+                >
+                  업체 유형을 선택하세요
+                </span>
+                <span
+                  style={{
+                    color: "red",
+                    marginLeft: "4px",
+                    marginRight: "24px",
+                  }}
+                >
+                  *
+                </span>
+                <RadioGroup
+                  value={formData.type}
+                  onValueChange={(e) => handleInputUpdate("type", e.value)}
+                >
+                  <HStack gap={6}>
+                    <Radio value="CUSTOMER" disabled>
+                      고객사
+                    </Radio>
+                    <Radio value="DEVELOPER" disabled>
+                      개발사
+                    </Radio>
+                  </HStack>
+                </RadioGroup>
+              </Flex>
+            </Box>
+          </Flex>
+          {/* 업체명 및 사업자 등록번호 */}
+          <Flex gap={4} align="center">
+            {/* 업체명 (수정 불가) */}
+            <Box flex="2">
+              <InputForm
+                id="name"
+                type="text"
+                label="업체명"
+                value={formData.name}
+                disabled
+              />
+            </Box>
+            {/* 대표자 연락처 입력 */}
+            <Box flex="1">
+              <InputForm
+                id="phoneNumber"
+                type="tel"
+                label="대표자 연락처"
+                value={formData.phoneNumber}
+                onChange={(e) =>
+                  handleInputUpdate("phoneNumber", e.target.value)
+                }
+                error={errors.phoneNumber ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
+                isChanged={!!isChanged["phoneNumber"]}
+              />
+            </Box>
+            <Box flex="1"></Box>
+          </Flex>
+          {/* 대표자 연락처 및 사업자 등록증 첨부 */}
+          <Flex gap={4} align="center">
+            {/* 사업자 등록번호 입력 */}
+            <Box flex="1">
+              <InputForm
+                id="brNumber"
+                type="text"
+                label="사업자 등록번호"
+                placeholder="ex) 123-45-67890"
+                value={formData.brNumber}
+                error={errors.brNumber ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
+                onChange={(e) => handleInputUpdate("brNumber", e.target.value)}
+                isChanged={!!isChanged["brNumber"]}
+              />
+            </Box>
+            {/* 사업자 등록증 파일 첨부 */}
+            <Box flex="1" className={styles.inputFieldContainer}>
+              <label htmlFor="businessLicense" className={styles.label}>
+                사업자 등록증 첨부
+                <span className={styles.required}>*</span>
+              </label>
+              <>
+                <div className={styles.fileUploadContainer}>
+                  {/* ✅ 파일 첨부 버튼 */}
+                  <input
+                    type="file"
+                    id="businessLicense"
+                    className={styles.fileInputHidden}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        setSelectedFile(file);
+                        setFormData((prev) => ({
+                          ...prev,
+                          brCertificateUrl: `${file.name}|${URL.createObjectURL(file)}`,
+                        }));
+                        // 파일이 변경된 경우 isChanged에 반영
+                        setIsChanged((prev) => ({
+                          ...prev,
+                          brCertificateUrl: true, // 파일 변경 감지 추가
+                        }));
+                      }
+                    }}
+                  />
+                  <label
+                    htmlFor="businessLicense"
+                    className={styles.fileUploadButton}
+                  >
+                    파일 첨부
+                  </label>
+                  {/* 파일명 출력 및 클릭 시 새 탭에서 열기 */}
+                  {formData.brCertificateUrl ? (
+                    (() => {
+                      const fileData =
+                        typeof formData.brCertificateUrl === "string" &&
+                        formData.brCertificateUrl.includes("|")
+                          ? formData.brCertificateUrl.split("|")
+                          : [formData.brCertificateUrl, null];
+
+                      const fileName = fileData[0]
+                        ? fileData[0].replace(/^\d+_/, "")
+                        : "파일을 선택하세요";
+                      const fileUrl = fileData[1] || formData.brCertificateUrl;
+
+                      return fileUrl ? (
+                        <a
+                          href={fileUrl.split("|").pop()}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.selectedFileName}
+                        >
+                          ✔ {fileName}
+                        </a>
+                      ) : (
+                        <span
+                          className={styles.selectedFileName}
+                          onClick={() => fileInputRef.current?.click()}
+                        >
+                          ✔ {fileName}
+                        </span>
+                      );
+                    })()
+                  ) : (
+                    <span
+                      className={styles.selectedFileName}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      파일을 선택하세요
+                    </span>
+                  )}
+                </div>
+              </>
+              <span className={styles.errorText}> </span>
+            </Box>
+          </Flex>
+          {/* 사업장 주소 조회 및 입력 */}
+          <Flex gap={4} align="center">
+            {/* 사업장 주소(도로명) 검색 */}
+            <Box flex="1">
+              <InputForm
+                id="streetAddress"
+                type="address"
+                label="사업장 도로명 주소"
+                value={formData.streetAddress}
+                onChange={(e) =>
+                  handleInputUpdate("streetAddress", e.target.value)
+                }
+                error={errors.streetAddress ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
+                isChanged={!!isChanged["streetAddress"]}
+              />
+            </Box>
+            {/* 사업장 주소 상세 입력 */}
+            <Box flex="1">
+              <InputForm
+                id="detailAddress"
+                type="text"
+                label="사업장 상세 주소"
+                value={formData.detailAddress}
+                onChange={(e) =>
+                  handleInputUpdate("detailAddress", e.target.value)
+                }
+                error={errors.detailAddress ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
+                isChanged={!!isChanged["detailAddress"]}
+              />
+            </Box>
+          </Flex>
+          <Flex gap={4} align="center"></Flex>
+        </Flex>
+      </InputFormLayout>
+
+      <Stack align="flex-start">
+        <Tabs.RootProvider value={tabs}>
+          <Tabs.List>
+            <Tabs.Trigger
+              value="members"
+              onClick={() => {
+                const params = new URLSearchParams();
+                params.set("tab", "members"); // ✅ 탭 값만 유지, 나머지 초기화
+                route.push(`?${params.toString()}`);
               }}
             >
-              업체 유형을 선택하세요
-            </span>
-            <span
-              style={{ color: "red", marginLeft: "4px", marginRight: "24px" }}
+              <LuUser />
+              소속 회원
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="projects"
+              onClick={() => {
+                const params = new URLSearchParams();
+                params.set("tab", "projects"); // ✅ 탭 값만 유지, 나머지 초기화
+                route.push(`?${params.toString()}`);
+              }}
             >
-              *
-            </span>
-            <RadioGroup
-              value={formData.type}
-              onValueChange={(e) => handleInputUpdate("type", e.value)}
-            >
-              <HStack gap={6}>
-                <Radio value="CUSTOMER" disabled>
-                  고객사
-                </Radio>
-                <Radio value="DEVELOPER" disabled>
-                  개발사
-                </Radio>
-              </HStack>
-            </RadioGroup>
-          </Flex>
-        </Box>
-        <InputForm
-          id="name"
-          type="text"
-          label="업체명"
-          value={formData.name}
-          disabled
-        />
-        {/* 수정 가능 필드 */}
-        <Flex gap={4} align="center">
-          <Box flex="1">
-            <InputForm
-              id="brNumber"
-              type="text"
-              label="사업자 등록번호"
-              placeholder="ex) 123-45-67890"
-              value={formData.brNumber}
-              error={errors.brNumber ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
-              onChange={(e) => handleInputUpdate("brNumber", e.target.value)}
-              isChanged={!!isChanged["brNumber"]}
+              <LuFolder />
+              참여 중 프로젝트
+            </Tabs.Trigger>
+          </Tabs.List>
+
+          <Suspense>
+            <Tabs.Content value="members">
+              {/* 업체 별 소속 회원 목록 조회 */}
+              <OrganizationMemberList organizationId={organizationId} />
+            </Tabs.Content>
+            <Tabs.Content value="projects">
+              {/* 업체 별 참여 중 프로젝트 목록 조회 */}
+              <OrganizationProjectList organizationId={organizationId} />
+            </Tabs.Content>
+          </Suspense>
+        </Tabs.RootProvider>
+      </Stack>
+    </Flex>
+  );
+}
+
+// 업체 별 소속 회원 목록 조회
+function OrganizationMemberList({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const keyword = searchParams?.get("keyword") || "";
+  const memberRole = searchParams?.get("memberRole") || "";
+  const memberStatus = searchParams?.get("memberStatus") || "";
+  const currentPage = parseInt(searchParams?.get("currentPage") || "1", 10);
+  const memberPageSize = parseInt(
+    searchParams?.get("memberPageSize") || "10",
+    5,
+  );
+
+  const {
+    data: memberList,
+    paginationInfo,
+    loading: memberListLoading,
+    error: memberListError,
+    refetch,
+  } = useOrganizationMemberList(
+    organizationId,
+    keyword,
+    memberRole,
+    memberStatus,
+    currentPage,
+    memberPageSize,
+  );
+
+  // ✅ 상태 변경을 위한 로컬 상태 추가
+  const [memberData, setMemberData] = useState<MemberProps[]>([]);
+  useEffect(() => {
+    if (memberList) {
+      setMemberData(memberList);
+    }
+  }, [memberList]);
+
+  const [loadingId, setLoadingId] = useState<string | null>(null); // ✅ 특정 회원의 Switch 로딩 상태
+
+  // ✅ 회원 상태 변경 핸들러 (API 호출 및 UI 반영)
+  const handleStatusChange = async (
+    memberId: string,
+    currentStatus: string,
+  ) => {
+    setLoadingId(memberId); // ✅ 변경 중인 ID 설정 (로딩 표시)
+    try {
+      if (currentStatus === "ACTIVE") {
+        await deactivateMemberApi(memberId); // 비활성화 API 호출
+      } else {
+        await activateMemberApi(memberId); // 활성화 API 호출
+      }
+      alert("회원 상태가 변경되었습니다.");
+      // ✅ API 호출 후 로컬 상태 업데이트 (UI 즉시 반영)
+      setMemberData((prevMembers) =>
+        (prevMembers || []).map((member) =>
+          member.id === memberId
+            ? {
+                ...member,
+                memberStatus:
+                  currentStatus === "ACTIVE" ? "INACTIVE" : "ACTIVE",
+              }
+            : member,
+        ),
+      );
+      refetch();
+    } catch (error) {
+      console.error("회원 상태 변경 실패:", error);
+      alert("회원 상태 변경 중 오류가 발생했습니다.");
+    } finally {
+      setLoadingId(null); // ✅ 로딩 해제
+    }
+  };
+
+  const handleMemberPageChange = (page: number) => {
+    const params = new URLSearchParams(window.location.search);
+    // 쿼리스트링 업데이트
+    params.set("currentPage", page.toString());
+    // URL 업데이트
+    router.push(`?${params.toString()}`);
+  };
+
+  const handleRowClick = (memberId: string) => {
+    const member = memberList?.find((m) => m.id === memberId);
+    if (member) {
+      router.push(`/admin/members/${member.id}`);
+    }
+  };
+
+  const handleEdit = (memberId: string) => {
+    const member = memberList?.find((m) => m.id === memberId);
+    if (member) {
+      router.push(`/admin/members/${member.id}`);
+    }
+  };
+
+  const handleDelete = async (memberId: string) => {
+    const confirmDelete = window.confirm("정말로 삭제하시겠습니까?");
+    if (!confirmDelete) return;
+    try {
+      await deleteMember(memberId, "");
+      alert("회원이 탈퇴 조치 되었습니다.");
+      refetch();
+    } catch (error) {
+      alert(`삭제 중 문제가 발생했습니다 : ${error}`);
+    }
+  };
+
+  return (
+    <>
+      <Stack width="full">
+        <Flex justifyContent="end">
+          {/* 회원 검색/필터 섹션 (검색창, 필터 옵션 등) */}
+          <SearchSection
+            keyword={keyword}
+            placeholder="회원명 입력"
+            keywordName="keyword"
+            currentPageName="currentPage"
+          >
+            <FilterSelectBox
+              statusFramework={memberRoleFramework}
+              selectedValue={memberRole}
+              placeholder="역할"
+              queryKey="memberRole"
+              width="100px"
             />
-          </Box>
-          <Box flex="1" className={styles.inputFieldContainer}>
-            <label htmlFor="businessLicense" className={styles.label}>
-              사업자 등록증 첨부
-              <span className={styles.required}>*</span>
-            </label>
-            <>
-              <div className={styles.fileUploadContainer}>
-                {/* ✅ 파일 첨부 버튼 */}
-                <input
-                  type="file"
-                  id="businessLicense"
-                  className={styles.fileInputHidden}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                      setSelectedFile(file);
-                      setFormData((prev) => ({
-                        ...prev,
-                        brCertificateUrl: `${file.name}|${URL.createObjectURL(file)}`,
-                      }));
-                      // 파일이 변경된 경우 isChanged에 반영
-                      setIsChanged((prev) => ({
-                        ...prev,
-                        brCertificateUrl: true, // 파일 변경 감지 추가
-                      }));
-                    }
-                  }}
-                />
-                <label
-                  htmlFor="businessLicense"
-                  className={styles.fileUploadButton}
-                >
-                  파일 첨부
-                </label>
-                {/* 파일명 출력 및 클릭 시 새 탭에서 열기 */}
-                {formData.brCertificateUrl ? (
-                  (() => {
-                    const fileData =
-                      typeof formData.brCertificateUrl === "string" &&
-                      formData.brCertificateUrl.includes("|")
-                        ? formData.brCertificateUrl.split("|")
-                        : [formData.brCertificateUrl, null];
-
-                    const fileName = fileData[0]
-                      ? fileData[0].replace(/^\d+_/, "")
-                      : "파일을 선택하세요";
-                    const fileUrl = fileData[1] || formData.brCertificateUrl;
-
-                    return fileUrl ? (
-                      <a
-                        href={fileUrl.split("|").pop()}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={styles.selectedFileName}
-                      >
-                        ✔ {fileName}
-                      </a>
-                    ) : (
-                      <span
-                        className={styles.selectedFileName}
-                        onClick={() => fileInputRef.current?.click()}
-                      >
-                        ✔ {fileName}
-                      </span>
-                    );
-                  })()
-                ) : (
-                  <span
-                    className={styles.selectedFileName}
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    파일을 선택하세요
-                  </span>
-                )}
-              </div>
-            </>
-            <span className={styles.errorText}> </span>
-          </Box>
+            <FilterSelectBox
+              statusFramework={memberStatusFramework}
+              selectedValue={memberStatus}
+              placeholder="활성화 여부"
+              queryKey="memberStatus"
+              width="150px"
+            />
+          </SearchSection>
         </Flex>
-        <InputForm
-          id="streetAddress"
-          type="address"
-          label="사업장 도로명 주소"
-          value={formData.streetAddress}
-          onChange={(e) => handleInputUpdate("streetAddress", e.target.value)}
-          error={errors.streetAddress ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
-          isChanged={!!isChanged["streetAddress"]}
+        {memberListError && (
+          <ErrorAlert message="회원 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
+        <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="10%" />
+            </>
+          }
+          headerTitle={
+            <Table.Row
+              backgroundColor={"#eee"}
+              css={{
+                "& > th": { textAlign: "center" },
+              }}
+            >
+              <Table.ColumnHeader>역할</Table.ColumnHeader>
+              <Table.ColumnHeader>회원명</Table.ColumnHeader>
+              <Table.ColumnHeader>직무 | 직책</Table.ColumnHeader>
+              <Table.ColumnHeader>이메일</Table.ColumnHeader>
+              <Table.ColumnHeader>연락처</Table.ColumnHeader>
+              <Table.ColumnHeader>등록일</Table.ColumnHeader>
+              <Table.ColumnHeader>활성화 여부</Table.ColumnHeader>
+              <Table.ColumnHeader>관리</Table.ColumnHeader>
+            </Table.Row>
+          }
+          data={memberList || []}
+          loading={memberListLoading}
+          renderRow={(member) => {
+            return (
+              <Table.Row
+                key={member.id}
+                onClick={() => handleRowClick(member.id)}
+                css={{
+                  cursor: "pointer",
+                  "&:hover": { backgroundColor: "#f5f5f5" },
+                  "& > td": {
+                    textAlign: "center",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  },
+                }}
+              >
+                <Table.Cell>
+                  {ROLE_LABELS[member.role] || "알 수 없음"}
+                </Table.Cell>
+                <Table.Cell>{member.name}</Table.Cell>
+                <Table.Cell>{`${member.jobRole} | ${member.jobTitle}`}</Table.Cell>
+                <Table.Cell>{member.email}</Table.Cell>
+                <Table.Cell>{member.phoneNum}</Table.Cell>
+                <Table.Cell>{formatDynamicDate(member.regAt)}</Table.Cell>
+                <Table.Cell onClick={(event) => event.stopPropagation()}>
+                  {member.status === "DELETED" ? (
+                    <Switch disabled />
+                  ) : (
+                    <Switch
+                      checked={member.status === "ACTIVE"}
+                      onChange={(event) => {
+                        event.stopPropagation();
+                        handleStatusChange(member.id, member.status);
+                      }}
+                      disabled={loadingId === member.id} // ✅ 상태 변경 시 로딩 적용
+                    />
+                  )}
+                </Table.Cell>
+                <Table.Cell onClick={(event) => event.stopPropagation()}>
+                  <DropDownMenu
+                    onEdit={() => handleEdit(member.id)}
+                    onDelete={() => handleDelete(member.id)}
+                  />
+                </Table.Cell>
+              </Table.Row>
+            );
+          }}
         />
-        <InputForm
-          id="detailAddress"
-          type="text"
-          label="사업장 상세 주소"
-          value={formData.detailAddress}
-          onChange={(e) => handleInputUpdate("detailAddress", e.target.value)}
-          error={errors.detailAddress ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
-          isChanged={!!isChanged["detailAddress"]}
+        {/*
+         * 페이지네이션 컴포넌트
+         * paginationInfo: 현재 페이지, 총 페이지, 페이지 크기 등의 정보
+         * handleMemberPageChange: 페이지 이동 시 실행될 콜백
+         */}
+        <Pagination
+          paginationInfo={
+            paginationInfo && {
+              ...paginationInfo,
+              currentPage: paginationInfo.currentPage,
+            }
+          }
+          handlePageChange={handleMemberPageChange}
         />
-        <InputForm
-          id="phoneNumber"
-          type="tel"
-          label="대표자 연락처"
-          value={formData.phoneNumber}
-          onChange={(e) => handleInputUpdate("phoneNumber", e.target.value)}
-          error={errors.phoneNumber ?? undefined} // 에러 null 값을 undefined로 변환 (이하 동일)
-          isChanged={!!isChanged["phoneNumber"]}
+      </Stack>
+    </>
+  );
+}
+
+// 업체 별 참여 중 프로젝트 목록 조회
+function OrganizationProjectList({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const keyword = searchParams?.get("keyword") || "";
+  const managementStep = searchParams?.get("managementStep") || "";
+  const currentPage = parseInt(searchParams?.get("currentPage") || "1", 10);
+  const pageSize = parseInt(searchParams?.get("pageSize") || "10", 5);
+
+  const {
+    data: projectList,
+    paginationInfo,
+    loading: projectListLoading,
+    error: projectListError,
+  } = useOrganizationProjectList(
+    organizationId,
+    keyword,
+    managementStep,
+    currentPage,
+    pageSize,
+  );
+
+  /**
+   * 페이지 변경 시 호출되는 콜백 함수
+   * - 쿼리 파라미터를 갱신하고, fetchProjectList를 다시 호출합니다.
+   *
+   * @param page 새로 이동할 페이지 번호
+   */
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(window.location.search);
+    // 쿼리스트링 업데이트
+    params.set("currentPage", page.toString());
+    // URL 업데이트
+    router.push(`?${params.toString()}`);
+  };
+
+  /**
+   * 테이블 행 클릭 시 호출되는 콜백
+   * - 특정 프로젝트의 상세 화면(/projects/[id]/tasks)로 이동
+   *
+   * @param projectId 프로젝트 ID (백엔드 혹은 테이블에서 받아온 값)
+   */
+  const handleRowClick = (projectId: string) => {
+    const project = projectList?.find((p) => p.id === projectId);
+    if (project) {
+      router.push(`/projects/${project.id}/questions`);
+    }
+  };
+
+  return (
+    <>
+      <Stack width="full">
+        <Flex justifyContent="end">
+          {/* 프로젝트 검색/필터 섹션 (검색창, 필터 옵션 등) */}
+          <SearchSection keyword={keyword} placeholder="프로젝트명 입력">
+            <FilterSelectBox
+              statusFramework={projectStatusFramework}
+              selectedValue={managementStep}
+              placeholder="관리단계"
+              queryKey="managementStep"
+              width="150px"
+            />
+          </SearchSection>
+        </Flex>
+        {projectListError && (
+          <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
+        <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="15%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+              <Table.Column htmlWidth="12%" />
+            </>
+          }
+          headerTitle={
+            <Table.Row
+              backgroundColor={useColorModeValue("#eee", "gray.700")}
+              css={{
+                "& > th": { textAlign: "center" },
+              }}
+            >
+              <Table.ColumnHeader>프로젝트명</Table.ColumnHeader>
+              <Table.ColumnHeader>고객사</Table.ColumnHeader>
+              <Table.ColumnHeader>개발사</Table.ColumnHeader>
+              <Table.ColumnHeader>관리 단계</Table.ColumnHeader>
+              <Table.ColumnHeader>시작일</Table.ColumnHeader>
+              <Table.ColumnHeader>예상 마감일</Table.ColumnHeader>
+              <Table.ColumnHeader>납품 완료일</Table.ColumnHeader>
+            </Table.Row>
+          }
+          data={projectList || []}
+          loading={projectListLoading}
+          renderRow={(project) => {
+            return (
+              <Table.Row
+                key={project.id}
+                onClick={() => handleRowClick(project.id)}
+                css={{
+                  "&:hover": { backgroundColor: "#f1f1f1" },
+                  cursor: "pointer",
+                  opacity: 1,
+                  "& > td": { textAlign: "center" },
+                }}
+              >
+                <Table.Cell>{project.name}</Table.Cell>
+                <Table.Cell>{project.customerName}</Table.Cell>
+                <Table.Cell>{project.developerName}</Table.Cell>
+                <Table.Cell>
+                  <StatusTag>{STATUS_LABELS[project.managementStep]}</StatusTag>
+                </Table.Cell>
+                <Table.Cell>{formatDynamicDate(project.startAt)}</Table.Cell>
+                <Table.Cell>{formatDynamicDate(project.deadlineAt)}</Table.Cell>
+                <Table.Cell>
+                  {formatDynamicDate(project.closeAt) === ""
+                    ? "-"
+                    : formatDynamicDate(project.closeAt)}
+                </Table.Cell>
+              </Table.Row>
+            );
+          }}
         />
-      </InputFormLayout>
+        <Pagination
+          paginationInfo={
+            paginationInfo && {
+              ...paginationInfo,
+              currentPage: paginationInfo.currentPage,
+            }
+          }
+          handlePageChange={handlePageChange}
+        />
+      </Stack>
     </>
   );
 }

--- a/src/components/pages/AdminOrganizationsPage/index.tsx
+++ b/src/components/pages/AdminOrganizationsPage/index.tsx
@@ -22,6 +22,7 @@ import ErrorAlert from "@/src/components/common/ErrorAlert";
 import DropDownMenu from "@/src/components/common/DropDownMenu";
 import { deleteOriginationWithReason } from "@/src/api/organizations";
 import { useUpdateOrganizationStatus } from "@/src/hook/useMutationData";
+// import StatusTag from "../../common/StatusTag";
 
 const organizationTypeFramework = createListCollection<{
   label: string;
@@ -175,7 +176,7 @@ function AdminOrganizationsPageContent() {
             <Table.Row
               backgroundColor={"#eee"}
               css={{
-                "& > th": { textAlign: "center" },
+                "& > th": { textAlign: "center", whiteSpace: "nowrap" },
               }}
             >
               <Table.ColumnHeader>업체유형</Table.ColumnHeader>
@@ -183,8 +184,8 @@ function AdminOrganizationsPageContent() {
               <Table.ColumnHeader>사업자등록번호</Table.ColumnHeader>
               <Table.ColumnHeader>연락처</Table.ColumnHeader>
               <Table.ColumnHeader>주소</Table.ColumnHeader>
-              <Table.ColumnHeader>상태</Table.ColumnHeader>
               <Table.ColumnHeader>등록일</Table.ColumnHeader>
+              <Table.ColumnHeader>상태</Table.ColumnHeader>
               <Table.ColumnHeader>관리</Table.ColumnHeader>
             </Table.Row>
           }
@@ -227,6 +228,11 @@ function AdminOrganizationsPageContent() {
                 )}
               </Table.Cell>
               <Table.Cell>{formatDynamicDate(organization.regAt)}</Table.Cell>
+              {/* <Table.Cell>
+                <StatusTag>
+                  {STATUS_LABELS[organization.status] || "-"}
+                </StatusTag>
+              </Table.Cell> */}
               <Table.Cell onClick={(event) => event.stopPropagation()}>
                 <DropDownMenu
                   onEdit={() => handleEdit(organization.id)}

--- a/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
@@ -10,7 +10,6 @@ import {
   Wrench,
 } from "lucide-react";
 import ProjectsManagementStepCard from "@/src/components/pages/ProjectWorkFlowPage/components/ProjectsManagementStepCard";
-import { useColorModeValue } from "@/src/components/ui/color-mode";
 import { ProjectManagementSteps } from "@/src/constants/projectManagementSteps";
 import ConfirmDialog from "@/src/components/common/ConfirmDialog";
 import { projectManagementStepApi } from "@/src/api/projects";
@@ -39,9 +38,9 @@ export default function ProjectsManagementStepCards({
   const [selectedStep, setSelectedStep] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
 
-  const bgColor = useColorModeValue("white", "gray.800");
-  const borderColor = useColorModeValue("gray.200", "gray.700");
-  const textColor = useColorModeValue("gray.700", "gray.200");
+  // const bgColor = useColorModeValue("white", "gray.800");
+  // const borderColor = useColorModeValue("gray.200", "gray.700");
+  // const textColor = useColorModeValue("gray.700", "gray.200");
 
   const { data, refetch } = useProjectInfoContext();
   const currentManagementStep = data?.managementStep; // 현재 프로젝트 단계
@@ -129,12 +128,12 @@ export default function ProjectsManagementStepCards({
       mb="2rem"
       width="full"
       mx="auto"
-      bg={bgColor}
+      // bg={bgColor}
       transition="all 0.3s ease-in-out"
     >
       <Heading
         size="2xl"
-        color={textColor}
+        // color={textColor}
         mb="10px"
         textAlign="left"
         paddingX="0.3rem"
@@ -147,11 +146,11 @@ export default function ProjectsManagementStepCards({
         alignItems="center"
         paddingX="32px"
         paddingY={4}
-        border={`1px solid ${borderColor}`}
+        // border={`1px solid ${borderColor}`}
         borderRadius="lg"
         boxShadow="md"
         gap={4}
-        bg={bgColor}
+        // bg={bgColor}
       >
         {mappedData.map((item) => {
           const isCurrentStep = item.step === currentManagementStep;

--- a/src/components/pages/ProjectsCreatePage/components/OrganizationSelector.tsx
+++ b/src/components/pages/ProjectsCreatePage/components/OrganizationSelector.tsx
@@ -335,7 +335,6 @@ export default function OrganizationSelector({
                     )}
                   </Box>
                 </Flex>
-
                 <Box
                   border="1px solid #ccc"
                   borderRadius="0.5rem"

--- a/src/hook/useFetchBoardList.ts
+++ b/src/hook/useFetchBoardList.ts
@@ -8,17 +8,23 @@ import {
   NoticeListResponse,
   OrganizationListResponse,
   MemberListResponse,
+  OrganizationProjectListResponse,
+  MemberProjectListResponse,
 } from "@/src/types";
 import {
   fetchProjectQuestionListApi,
   fetchProjectApprovalListApi,
   fetchProjectListApi,
-  projectProgressStepApi,
+  fetchOrganizationProjectListApi,
+  fetchMemberProjectListApi,
 } from "@/src/api/projects";
 import { showToast } from "@/src/utils/showToast";
 import { fetchNoticeListApi } from "@/src/api/notices";
 import { fetchOrganizationListApi } from "@/src/api/organizations";
-import { fetchMemberListApi } from "@/src/api/members";
+import {
+  fetchMemberListApi,
+  fetchOrganizationMemberListApi,
+} from "@/src/api/members";
 
 interface UseFetchBoardListProps<T, P extends any[], K extends keyof T> {
   fetchApi: (...args: P) => Promise<CommonResponseWithMetaType<T>>;
@@ -157,6 +163,42 @@ export const useProjectList = (
     params: [keyword, status, currentPage, pageSize],
   });
 
+// 업체 별 참여 중인 프로젝트 목록 패칭
+export const useOrganizationProjectList = (
+  organizationId: string,
+  keyword: string,
+  managementStep: string,
+  currentPage: number,
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    OrganizationProjectListResponse,
+    [string, string, string, number, number],
+    "dtoList"
+  >({
+    fetchApi: fetchOrganizationProjectListApi,
+    keySelector: "dtoList",
+    params: [organizationId, keyword, managementStep, currentPage, pageSize],
+  });
+
+// 회원 별 참여 중인 프로젝트 목록 패칭
+export const useMemberProjectList = (
+  memberId: string,
+  keyword: string,
+  managementStep: string,
+  currentPage: number,
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    MemberProjectListResponse,
+    [string, string, string, number, number],
+    "dtoList"
+  >({
+    fetchApi: fetchMemberProjectListApi,
+    keySelector: "dtoList",
+    params: [memberId, keyword, managementStep, currentPage, pageSize],
+  });
+
 // 공지사항 목록 패칭
 export const useNoticeList = (
   keyword: string,
@@ -191,6 +233,25 @@ export const useMemberList = (
     fetchApi: fetchMemberListApi,
     keySelector: "members",
     params: [keyword, role, status, currentPage, pageSize],
+  });
+
+// 업체 별 소속 회원 목록 패칭
+export const useOrganizationMemberList = (
+  organizationId: string,
+  keyword: string,
+  role: string,
+  status: string,
+  currentPage: number,
+  pageSize: number,
+) =>
+  useFetchBoardList<
+    MemberListResponse,
+    [string, string, string, string, number, number],
+    "members"
+  >({
+    fetchApi: fetchOrganizationMemberListApi,
+    keySelector: "members",
+    params: [organizationId, keyword, role, status, currentPage, pageSize],
   });
 
 // 업체 목록 패칭

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,6 +221,18 @@ export interface ProjectListResponse {
   meta: PaginationProps; // 페이지네이션 메타 정보
 }
 
+// 업체 별 참여 중 프로젝트 목록 조회 API 응답 결과
+export interface OrganizationProjectListResponse {
+  dtoList: ProjectProps[];
+  meta: PaginationProps; // 페이지네이션 메타 정보
+}
+
+// 회원 별 참여 중 프로젝트 목록 조회 API 응답 결과
+export interface MemberProjectListResponse {
+  dtoList: ProjectProps[];
+  meta: PaginationProps; // 페이지네이션 메타 정보
+}
+
 export interface ProjectSidebarProps {
   id: string;
   name: string;


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 업체 별 소속회원 및 참여 프로젝트 목록 조회 기능 구현
- Related to #191 

### 🔧 What has been changed?

- 회원 별 참여 프로젝트 목록 조회 기능 구현
- 글로벌 스타일 파일 수정 `globals.css`
- 
### 📸 Screenshots / GIFs (if applicable)

![image](https://github.com/user-attachments/assets/386c0533-7d6d-4e35-b304-fe708e422c68)
![image](https://github.com/user-attachments/assets/c3177052-da91-49fb-b861-0b5fa8e3d25c)

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
