### PR TITLE
프로젝트 상세페이지 레이아웃 수정

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -48,7 +48,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     <SidebarProvider>
       <Flex
         direction="column"
-        minHeight="100vh"
+        minHeight="100%"
         bg={bgColor}
         transition="background-color 0.3s"
       >

--- a/src/components/common/FilterSelectBox.tsx
+++ b/src/components/common/FilterSelectBox.tsx
@@ -67,7 +67,11 @@ export default function FilterSelectBox({
       onValueChange={handleValueChange}
     >
       {/* 드롭다운 버튼(트리거) */}
-      <SelectTrigger>
+      <SelectTrigger
+        border={"1px solid #e4e4e7"}
+        borderRadius="0.3rem"
+        height="2.45rem"
+      >
         {/* 선택된 값이 표시될 영역 */}
         <SelectValueText
           textAlign="center"

--- a/src/components/common/ProgressStepButton.tsx
+++ b/src/components/common/ProgressStepButton.tsx
@@ -17,15 +17,15 @@ export default function ProgressStepButton({
     <Button
       onClick={onClick}
       width="11%"
-      height="48px"
-      padding="14px 16px"
+      height="3rem"
+      padding="1rem"
       justifyContent="center"
       alignItems="center"
-      borderRadius="4px"
+      borderRadius="1rem"
       bg="white"
       color="black"
       overflow="hidden"
-      border={isSelected ? "2px solid #D62A1C" : "1px solid #E5E5EC"} // 클릭 상태에 따라 테두리 변경
+      border={isSelected ? "1px solid #D62A1C" : "3px solid #E5E5EC"} // 클릭 상태에 따라 테두리 변경
       textAlign="center"
     >
       {/* <Text>{text}</Text> */}

--- a/src/components/common/ProgressStepSection.tsx
+++ b/src/components/common/ProgressStepSection.tsx
@@ -51,18 +51,12 @@ export default function ProgressStepSection({
 
   return (
     <Flex
+      marginY="1rem"
       alignItems="center"
-      justifyContent="flex-start"
+      justifyContent="center"
       width="100%"
-      paddingX="2rem"
       paddingY="1rem"
-      gap="1rem"
-      // gap={gapValue}
-      border="1px solid"
-      borderColor="gray.200"
-      borderRadius="lg"
-      boxShadow="md"
-      mb="30px"
+      gap="1.5rem"
       flexWrap="nowrap"
       overflowX="auto"
       whiteSpace="nowrap"

--- a/src/components/common/ProjectInfoSection222.tsx
+++ b/src/components/common/ProjectInfoSection222.tsx
@@ -1,0 +1,89 @@
+import { Box, Text, HStack, VStack, Flex } from "@chakra-ui/react";
+import { Avatar } from "@/src/components/ui/avatar";
+import { ProjectInfoProps } from "@/src/types";
+import { formatDynamicDate } from "@/src/utils/formatDateUtil";
+import { Loading } from "@/src/components/common/Loading";
+import { Phone } from "lucide-react";
+
+interface ProjectInfoSectionProps {
+  projectInfo: ProjectInfoProps | null;
+  loading: boolean;
+}
+
+// 프로젝트 기본정보 컴포넌트
+export default function ProjectInfoSection222({
+  projectInfo,
+  loading,
+}: ProjectInfoSectionProps) {
+  if (loading) {
+    return <Loading />;
+  }
+  return (
+    <>
+      {/* 고객사 정보 */}
+      <Box flex="1" borderRadius="md" bg="gray.50" boxSizing="content-box">
+        <HStack justifyContent="space-between">
+          <HStack gap="1rem">
+            <Text>🏢 고객사</Text>
+            <Text>|</Text>
+            <Box>
+              <Text fontSize="0.9rem" fontWeight="bold">
+                {projectInfo?.customerOrgName}
+              </Text>
+              <Text fontSize="0.8rem" color="gray.700">
+                {projectInfo?.customerOwnerName} |{" "}
+                {projectInfo?.customerJobTitle} |{" "}
+                {projectInfo?.developerJobRole}
+              </Text>
+              <Text fontSize="0.8rem" color="gray.700" marginLeft="0.2rem">
+                {projectInfo?.developerPhoneNum}
+              </Text>
+            </Box>
+          </HStack>
+        </HStack>
+      </Box>
+      {/* 개발사 정보 */}
+      <Box flex="1" borderRadius="md" bg="gray.50" boxSizing="content-box">
+        <HStack justifyContent="space-between">
+          <HStack gap="1rem">
+            <Text>🔧 개발사</Text>
+            <Text>|</Text>
+            <Box>
+              <Text fontSize="0.9rem" fontWeight="bold">
+                {projectInfo?.developerOrgName}
+              </Text>
+              <Text fontSize="0.8rem" color="gray.700">
+                {projectInfo?.developerOwnerName} |{" "}
+                {projectInfo?.developerJobTitle} |{" "}
+                {projectInfo?.customerJobRole}
+              </Text>
+              <Text fontSize="0.8rem" color="gray.700" marginLeft="0.2rem">
+                {projectInfo?.developerPhoneNum}
+              </Text>
+            </Box>
+          </HStack>
+        </HStack>
+      </Box>
+      {/* 프로젝트 일정 정보 */}
+      <Box flex="1" borderRadius="md" bg="gray.50" boxSizing="content-box">
+        <HStack justifyContent="space-between">
+          <HStack gap="1rem">
+            <Text>📅 프로젝트 일정</Text>
+            <Text>|</Text>
+            <Box>
+              <Text fontSize="0.9rem">
+                시작일: {formatDynamicDate(projectInfo?.startAt) || "-"}
+              </Text>
+              <Text fontSize="0.9rem">
+                마감일: {formatDynamicDate(projectInfo?.deadlineAt) || "-"}
+              </Text>{" "}
+              <Text fontSize="0.9rem">
+                종료일: {formatDynamicDate(projectInfo?.closeAt) || "-"}
+              </Text>
+            </Box>
+          </HStack>
+        </HStack>
+      </Box>
+    </>
+  );
+}

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -51,7 +51,7 @@ export default function SearchSection({
   };
 
   return (
-    <Box mb="10px">
+    <Box mb="0.8rem">
       <Flex gap={4} alignItems="center" justifyContent="end">
         <HStack>
           {children}
@@ -61,12 +61,18 @@ export default function SearchSection({
             value={input}
             onChange={onChangeSearch}
             onKeyDown={onKeyDown}
-            width="300px"
+            width="23rem"
           />
-          <Button width="80px" variant={"surface"} onClick={onSubmit}>
+          <Button width="4rem" variant={"surface"} onClick={onSubmit}>
             검색
           </Button>
-          <Button width="80px" variant={"outline"} onClick={resetSearch}>
+          <Button
+            width="4rem"
+            padding={"1.2rem"}
+            border={"1px solid #e4e4e7"}
+            backgroundColor="white"
+            onClick={resetSearch}
+          >
             초기화
           </Button>
         </HStack>

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -2,12 +2,13 @@
 
 import { ReactNode } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
-import { Flex, Heading, HStack, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Text } from "@chakra-ui/react";
 import { Layers, List, MessageCircleQuestion } from "lucide-react";
 import { SegmentedControl } from "@/src/components/ui/segmented-control";
 import ProjectInfoSection from "@/src/components/common/ProjectInfoSection";
 import ErrorAlert from "@/src/components/common/ErrorAlert";
 import { useProjectInfoContext } from "@/src/context/ProjectInfoContext";
+import ProjectInfoSection222 from "../common/ProjectInfoSection222";
 
 interface ProjectLayoutProps {
   children: ReactNode;
@@ -74,58 +75,75 @@ export function ProjectLayout({ children }: ProjectLayoutProps) {
   };
 
   return (
-    <>
-      {/* 슬라이더 탭 */}
-      <SegmentedControl
-        value={currentTab}
-        onValueChange={handleTabChange}
-        items={projectMenu}
-      />
+    <Flex direction="column" marginTop="1rem">
       {projectInfoError && (
         <ErrorAlert message="프로젝트 기본 정보를 불러오지 못했습니다. 다시 시도해주세요." />
       )}
-      {/* 상단 영역 */}
+      {/* 프로젝트 및 업체 정보 */}
       <Flex
         direction="column"
-        padding="30px 23px 15px 23px"
-        gap="8px"
-        border="1px solid"
-        borderColor="gray.200"
-        borderRadius="lg"
-        boxShadow="md"
-        mb="30px"
+        gap="1rem"
+        padding="1.2rem"
+        border="1px solid #b8b1b1"
+        borderRadius="1.5rem"
+        marginBottom="2rem"
       >
         <Flex
-          justifyContent={"space-between"}
+          direction="row"
+          gap="3rem"
           alignItems="center"
-          // height="4rem"
+          justifyContent="space-between"
         >
-          {/* 프로젝트 제목 및 설명 */}
-          <Flex gap="10px" alignItems="center">
-            <Heading size={"4xl"} paddingLeft="1.5rem">
+          <Box flex="1.1">
+            <Heading fontSize="1.5rem" paddingLeft="0.5rem">
               {projectInfo?.projectName}
             </Heading>
-            <Text fontWeight="500" color="#BBB" fontSize="20px">
-              {projectInfo?.description}
-            </Text>
-          </Flex>
-          <Text
-            fontWeight="bold"
-            fontSize="20px"
-            paddingRight="2rem"
-            color="#0c9ae0"
-          >
-            &bull; {MANAGEMENT_STEP_LABELS[projectInfo?.managementStep || ""]}
-          </Text>
+          </Box>
+          {/* 프로젝트 정보 */}
+          <ProjectInfoSection222
+            projectInfo={projectInfo}
+            loading={projectInfoLoading}
+          />
         </Flex>
-        {/* 프로젝트 정보 */}
-        <ProjectInfoSection
-          projectInfo={projectInfo}
-          loading={projectInfoLoading}
-        />
+        <Text fontSize="1rem" fontStyle="italic" paddingLeft="0.5rem">
+          {projectInfo?.description}
+        </Text>
       </Flex>
 
-      {children}
-    </>
+      {/* 게시판 탭, 관리 단계 표시 */}
+      <Flex
+        direction="row"
+        justifyContent={"space-between"}
+        alignItems="center"
+      >
+        {/* 슬라이더 탭 */}
+        <SegmentedControl
+          value={currentTab}
+          onValueChange={handleTabChange}
+          items={projectMenu}
+        />
+        <Text
+          fontWeight="bold"
+          fontSize="1rem"
+          paddingRight="1rem"
+          color="#0c9ae0"
+        >
+          &bull; {MANAGEMENT_STEP_LABELS[projectInfo?.managementStep || ""]}{" "}
+          단계
+        </Text>
+      </Flex>
+
+      <Flex
+        direction="column"
+        gap="1rem"
+        padding="1.2rem"
+        border="1px solid #b8b1b1"
+        borderRadius="0.8rem"
+        height="fit-content"
+        minHeight="500px"
+      >
+        {children}
+      </Flex>
+    </Flex>
   );
 }

--- a/src/components/pages/ProjectApprovalsPage/index.tsx
+++ b/src/components/pages/ProjectApprovalsPage/index.tsx
@@ -106,16 +106,7 @@ export default function ProjectApprovalsPage() {
         progressStep={approvalProgressStepData || []}
         loading={approvalProgressStepLoading}
       />
-      <Box
-        direction="column"
-        padding="30px 23px"
-        gap="8px"
-        border="1px solid"
-        borderColor="gray.200"
-        borderRadius="lg"
-        boxShadow="md"
-        mb="30px"
-      >
+      <Box direction="column" paddingX="1rem" gap="8px" mb="30px">
         <Flex justifyContent={"space-between"} paddingX="0.3rem">
           <Button
             variant={"surface"}
@@ -131,10 +122,11 @@ export default function ProjectApprovalsPage() {
           {/* 검색 섹션 */}
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <StatusSelectBox
-              placeholder="결재상태"
+              placeholder="결재 여부"
               statusFramework={approvalStatusFramework}
               selectedValue={status}
               queryKey="status"
+              width="150px"
             />
           </SearchSection>
         </Flex>

--- a/src/components/pages/ProjectQuestionsPage/index.tsx
+++ b/src/components/pages/ProjectQuestionsPage/index.tsx
@@ -105,19 +105,13 @@ export default function ProjectQuestionsPage() {
         loading={questionProgressStepLoading}
       />
 
-      <Box
-        direction="column"
-        padding="30px 23px"
-        gap="8px"
-        border="1px solid"
-        borderColor="gray.200"
-        borderRadius="lg"
-        boxShadow="md"
-        mb="30px"
-      >
-        <Flex justifyContent={"space-between"}>
+      <Box direction="column" paddingX="1rem" gap="8px" mb="30px">
+        <Flex justifyContent={"space-between"} paddingX="0.3rem">
           <Button
             variant={"surface"}
+            backgroundColor="#00a8ff"
+            color="white"
+            border="none"
             _hover={{ backgroundColor: "#00a8ff", color: "white" }}
             onClick={handleProjectQuestionCreateButton}
           >
@@ -126,10 +120,11 @@ export default function ProjectQuestionsPage() {
           {/* 검색 섹션 */}
           <SearchSection keyword={keyword} placeholder="제목 입력">
             <FilterSelectBox
-              placeholder="질문상태"
+              placeholder="답변 여부"
               statusFramework={questionStatusFramework}
               selectedValue={status}
               queryKey="status"
+              width="130px"
             />
           </SearchSection>
         </Flex>

--- a/src/components/pages/ProjectWorkFlowPage/components/DateSection.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/DateSection.tsx
@@ -6,17 +6,13 @@ import "react-datepicker/dist/react-datepicker.css";
 import { Flex, Text, Box, Input } from "@chakra-ui/react";
 
 interface DateSectionProps {
-  startAt: Date | null;
-  closeAt: Date | null;
-  setStartAt: (value: Date | null) => void;
-  setCloseAt: (value: Date | null) => void;
+  dateTime?: Date | null;
+  setDateTime?: (value: Date | null) => void;
 }
 
 export default function DateSection({
-  startAt,
-  closeAt,
-  setStartAt,
-  setCloseAt,
+  dateTime,
+  setDateTime,
 }: DateSectionProps) {
   return (
     <Flex direction="column" width="100%">
@@ -31,13 +27,13 @@ export default function DateSection({
       >
         {/* 시작일 선택 */}
         <Box flex="1" minWidth="14rem" width="100%">
-          <Text fontSize="1rem" fontWeight="bold" mb="0.5rem">
+          {/* <Text fontSize="1rem" fontWeight="bold" mb="0.5rem">
             시작일
-          </Text>
+          </Text> */}
           <Box width="100%">
             <DatePicker
-              selected={startAt}
-              onChange={setStartAt}
+              selected={dateTime}
+              onChange={setDateTime}
               dateFormat="yyyy-MM-dd HH:mm"
               showTimeSelect // 시간 선택 활성화
               timeFormat="HH:mm" // 4시간제 포맷
@@ -47,7 +43,7 @@ export default function DateSection({
               customInput={
                 <Input
                   placeholder="날짜를 선택하세요"
-                  value={startAt ? startAt.toLocaleDateString("ko-KR") : ""}
+                  value={dateTime ? dateTime.toLocaleDateString("ko-KR") : ""}
                   readOnly
                   width="100%"
                   height="3rem"
@@ -55,37 +51,7 @@ export default function DateSection({
                   borderRadius="0.5rem"
                   border="1px solid #ccc"
                   lineHeight="1.5rem"
-                />
-              }
-            />
-          </Box>
-        </Box>
-        -{/* 종료일 선택 */}
-        <Box flex="1" minWidth="12rem" width="100%">
-          <Text fontSize="1rem" fontWeight="bold" mb="0.5rem">
-            예정완료일
-          </Text>
-          <Box width="100%">
-            <DatePicker
-              selected={closeAt}
-              onChange={setCloseAt}
-              dateFormat="yyyy-MM-dd HH:mm"
-              showTimeSelect // 시간 선택 활성화
-              timeFormat="HH:mm" // 4시간제 포맷
-              timeIntervals={60} // 10분 단위 선택
-              minDate={new Date()}
-              popperPlacement="bottom-start"
-              customInput={
-                <Input
-                  placeholder="날짜를 선택하세요"
-                  value={closeAt ? closeAt.toLocaleDateString("ko-KR") : ""}
-                  readOnly
-                  width="100%"
-                  height="3rem"
-                  padding="0.75rem"
-                  borderRadius="0.5rem"
-                  border="1px solid #ccc"
-                  lineHeight="1.5rem"
+                  textAlign="center"
                 />
               }
             />

--- a/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards.tsx
@@ -124,33 +124,21 @@ export default function ProjectsManagementStepCards({
   };
 
   return (
-    <Box
-      mb="2rem"
+    <Flex
+      margin="2rem 1rem 3rem 1.3rem"
       width="full"
-      mx="auto"
-      // bg={bgColor}
+      alignItems="center"
+      gap="3rem"
       transition="all 0.3s ease-in-out"
     >
-      <Heading
-        size="2xl"
-        // color={textColor}
-        mb="10px"
-        textAlign="left"
-        paddingX="0.3rem"
-      >
-        {title}
-      </Heading>
+      <Box>
+        <Heading fontSize="1.3rem">{title}</Heading>
+      </Box>
       <Flex
         wrap="nowrap"
-        justifyContent="flex-start"
+        justifyContent="center"
         alignItems="center"
-        paddingX="32px"
-        paddingY={4}
-        // border={`1px solid ${borderColor}`}
-        borderRadius="lg"
-        boxShadow="md"
-        gap={4}
-        // bg={bgColor}
+        gap="2rem"
       >
         {mappedData.map((item) => {
           const isCurrentStep = item.step === currentManagementStep;
@@ -181,6 +169,6 @@ export default function ProjectsManagementStepCards({
         cancelText="취소"
         isLoading={isLoading}
       />
-    </Box>
+    </Flex>
   );
 }

--- a/src/components/pages/ProjectWorkFlowPage/index.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/index.tsx
@@ -6,7 +6,6 @@ import "react-datepicker/dist/react-datepicker.css";
 import { Heading, Table, Button, Flex } from "@chakra-ui/react";
 import { ProjectLayout } from "@/src/components/layouts/ProjectLayout";
 import ProjectsManagementStepCards from "@/src/components/pages/ProjectWorkFlowPage/components/ProjectManagementStepCards";
-import { useColorModeValue } from "@/src/components/ui/color-mode";
 import CommonTable from "@/src/components/common/CommonTable";
 import ErrorAlert from "@/src/components/common/ErrorAlert";
 import { useProjectProgressStepData } from "@/src/hook/useFetchData";
@@ -40,8 +39,6 @@ export default function ProjectWorkFlowPage() {
   } = useProjectProgressStepData(projectId as string);
 
   const { mutate: updateProgressStep } = useUpdateProjectProgressStep();
-
-  const textColor = useColorModeValue("gray.700", "gray.200");
 
   // 날짜 상태 관리
   const [dates, setDates] = useState<
@@ -81,121 +78,129 @@ export default function ProjectWorkFlowPage() {
   };
 
   return (
-    <>
-      <ProjectLayout>
-        <ProjectsManagementStepCards title={"관리 단계 변경"} />
-      </ProjectLayout>
-
-      <Heading
-        size="2xl"
-        color={textColor}
-        lineHeight="base"
-        paddingLeft="0.3rem"
-        paddingBottom="0.7rem"
-      >
-        진행단계 요약
-      </Heading>
-      {progressStepError && (
-        <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
-      )}
-
-      {/*
-       * 공통 테이블(CommonTable)
-       *  - headerTitle: 테이블 헤더 구성
-       *  - data: 테이블에 표시될 데이터
-       *  - loading: 로딩 상태
-       *  - renderRow: 한 줄씩 어떻게 렌더링할지 정의 (jsx 반환)
-       *  - handleRowClick: 행 클릭 이벤트 핸들러
-       */}
-      <CommonTable
-        headerTitle={
-          <Table.Row
-            backgroundColor={useColorModeValue("#eee", "gray.700")}
-            css={{
-              "& > th": { textAlign: "center" },
-            }}
-          >
-            <Table.ColumnHeader>순서</Table.ColumnHeader>
-            <Table.ColumnHeader>진행단계명</Table.ColumnHeader>
-            <Table.ColumnHeader>날짜지정(시작일-완료예정일)</Table.ColumnHeader>
-            <Table.ColumnHeader>종료일시</Table.ColumnHeader>
-            <Table.ColumnHeader>승인자</Table.ColumnHeader>
-            <Table.ColumnHeader>로그</Table.ColumnHeader>
-          </Table.Row>
-        }
-        data={progressStepList ?? []}
-        loading={progressStepLoading}
-        renderRow={(progressStep, index = 0) => {
-          const isRowClickable = !!progressStep.relatedApprovalId;
-
-          return (
+    <ProjectLayout>
+      <ProjectsManagementStepCards title={"관리 단계 변경"} />
+      <Flex direction="column" marginX="1rem">
+        <Heading
+          lineHeight="base"
+          paddingBottom="0.7rem"
+          fontSize="1.3rem"
+          marginLeft="0.3rem"
+        >
+          진행단계 요약
+        </Heading>
+        {progressStepError && (
+          <ErrorAlert message="프로젝트 목록을 불러오지 못했습니다. 다시 시도해주세요." />
+        )}
+        {/*
+         * 공통 테이블(CommonTable)
+         *  - headerTitle: 테이블 헤더 구성
+         *  - data: 테이블에 표시될 데이터
+         *  - loading: 로딩 상태
+         *  - renderRow: 한 줄씩 어떻게 렌더링할지 정의 (jsx 반환)
+         *  - handleRowClick: 행 클릭 이벤트 핸들러
+         */}
+        <CommonTable
+          columnsWidth={
+            <>
+              <Table.Column htmlWidth="10%" />
+              <Table.Column htmlWidth="20%" />
+              <Table.Column htmlWidth="20%" />
+              <Table.Column htmlWidth="20%" />
+              <Table.Column htmlWidth="20%" />
+              <Table.Column htmlWidth="10%" />
+            </>
+          }
+          headerTitle={
             <Table.Row
-              key={progressStep.id}
-              onClick={(event) => {
-                if (isRowClickable) {
-                  router.push(
-                    `/projects/${resolvedProjectId}/approvals/${progressStep.relatedApprovalId}`,
-                  );
-                }
-                event.stopPropagation();
-              }}
+              backgroundColor="#eee"
               css={{
-                cursor: isRowClickable ? "pointer" : "default",
-                "&:hover": isRowClickable ? { backgroundColor: "#f5f5f5" } : {},
-                "& > td": { textAlign: "center" },
+                "& > th": { textAlign: "center", whiteSpace: "nowrap" },
               }}
             >
-              <Table.Cell>{index + 1}</Table.Cell>
-              <Table.Cell>{progressStep.name}</Table.Cell>
-              <Table.Cell>
-                <Flex>
-                  <DateSection
-                    startAt={
-                      dates[progressStep.id]?.startAt ??
-                      (progressStep.startAt
-                        ? new Date(progressStep.startAt)
-                        : null)
-                    }
-                    closeAt={
-                      dates[progressStep.id]?.deadlineAt ??
-                      (progressStep.deadlineAt
-                        ? new Date(progressStep.deadlineAt)
-                        : null)
-                    }
-                    setStartAt={(value) =>
-                      handleDateChange(progressStep.id, "startAt", value)
-                    }
-                    setCloseAt={(value) =>
-                      handleDateChange(progressStep.id, "deadlineAt", value)
-                    }
-                  />
-                  <Button
-                    colorScheme="blue"
-                    size="sm"
-                    onClick={() => handleSaveDates(progressStep.id)}
-                    disabled={
-                      !dates[progressStep.id]?.startAt ||
-                      !dates[progressStep.id]?.deadlineAt
-                    }
-                  >
-                    저장
-                  </Button>
-                </Flex>
-              </Table.Cell>
-              <Table.Cell>{progressStep.closeAt || "-"}</Table.Cell>
-              <Table.Cell>{progressStep.relatedApprovalId || "-"}</Table.Cell>
-              <Table.Cell>
-                <CustomModal title="결제 로그" triggerText="로그">
-                  <ProjectLogTable
-                    projectId={resolvedProjectId}
-                    progressStepId={progressStep.id}
-                  />
-                </CustomModal>
-              </Table.Cell>
+              <Table.ColumnHeader>순서</Table.ColumnHeader>
+              <Table.ColumnHeader>진행 단계명</Table.ColumnHeader>
+              <Table.ColumnHeader>작업 시작일</Table.ColumnHeader>
+              <Table.ColumnHeader>완료 예정일</Table.ColumnHeader>
+              <Table.ColumnHeader>결재 담당자</Table.ColumnHeader>
+              <Table.ColumnHeader>로그</Table.ColumnHeader>
             </Table.Row>
-          );
-        }}
-      />
-    </>
+          }
+          data={progressStepList ?? []}
+          loading={progressStepLoading}
+          renderRow={(progressStep, index = 0) => {
+            const isRowClickable = !!progressStep.relatedApprovalId;
+
+            return (
+              <Table.Row
+                key={progressStep.id}
+                onClick={(event) => {
+                  if (isRowClickable) {
+                    router.push(
+                      `/projects/${resolvedProjectId}/approvals/${progressStep.relatedApprovalId}`,
+                    );
+                  }
+                  event.stopPropagation();
+                }}
+                css={{
+                  cursor: isRowClickable ? "pointer" : "default",
+                  "&:hover": isRowClickable
+                    ? { backgroundColor: "#f5f5f5" }
+                    : {},
+                  "& > td": {
+                    textAlign: "center",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  },
+                }}
+              >
+                <Table.Cell>{index + 1}</Table.Cell>
+                <Table.Cell>{progressStep.name}</Table.Cell>
+                <Table.Cell>
+                  <Flex direction="row">
+                    <DateSection
+                      dateTime={
+                        dates[progressStep.id]?.startAt ??
+                        (progressStep.startAt
+                          ? new Date(progressStep.startAt)
+                          : null)
+                      }
+                      setDateTime={(value) =>
+                        handleDateChange(progressStep.id, "startAt", value)
+                      }
+                    />
+                  </Flex>
+                </Table.Cell>
+                <Table.Cell>
+                  <Flex direction="row">
+                    <DateSection
+                      dateTime={
+                        dates[progressStep.id]?.deadlineAt ??
+                        (progressStep.deadlineAt
+                          ? new Date(progressStep.deadlineAt)
+                          : null)
+                      }
+                      setDateTime={(value) =>
+                        handleDateChange(progressStep.id, "deadlineAt", value)
+                      }
+                    />
+                  </Flex>
+                </Table.Cell>
+                <Table.Cell>{progressStep.approver?.name || "-"}</Table.Cell>
+                <Table.Cell>
+                  <CustomModal title="결제 로그" triggerText="로그">
+                    <ProjectLogTable
+                      projectId={resolvedProjectId}
+                      progressStepId={progressStep.id}
+                    />
+                  </CustomModal>
+                </Table.Cell>
+              </Table.Row>
+            );
+          }}
+        />
+      </Flex>
+    </ProjectLayout>
   );
 }

--- a/src/components/pages/ProjectsPage/index.tsx
+++ b/src/components/pages/ProjectsPage/index.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Head from "next/head";
 import {
   Box,
-  Button,
   createListCollection,
   Flex,
   Heading,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -277,6 +277,7 @@ export interface ProgressStep {
   deadlineAt: string;
   projectId: string;
   relatedApprovalId: string;
+  approver: Approver;
 }
 
 export interface Register {


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE] 프로젝트 상세페이지 레이아웃 수정
- Related to #198 

### 🔧 What has been changed?

- 프로젝트 결재관리 / 질문관리 / 진척관리 게시판 레이아웃 일관성 맞춤

### 📸 Screenshots / GIFs (if applicable)

![image](https://github.com/user-attachments/assets/2405bff8-884e-448a-a0ab-73e9a108aaef)
![image](https://github.com/user-attachments/assets/86db56cd-d92b-4f8d-bd18-49e629651eb9)
![image](https://github.com/user-attachments/assets/a11d0418-7e08-471d-8b5c-12e900c8f3f1)


### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
