### PR TITLE
alert 구문 toast 메시지로 변경 및 UI/UX 개선

### DIFF
--- a/src/api/ReadArticle.ts
+++ b/src/api/ReadArticle.ts
@@ -15,72 +15,50 @@ export async function readQuestionApi(
   projectId: number,
   questionId: number,
 ): Promise<QuestionArticle> {
-  try {
-    const response = await axiosInstance.get<QuestionApiResponse>(
-      `${BASE_URL}/projects/${projectId}/questions/${questionId}`,
-    );
+  const response = await axiosInstance.get<QuestionApiResponse>(
+    `${BASE_URL}/projects/${projectId}/questions/${questionId}`,
+  );
 
-    return response.data.data;
-  } catch (error) {
-    console.error("API 호출 실패:", error);
-    throw new Error("질문 데이터를 가져오는 중 문제가 발생했습니다.");
-  }
+  return response.data.data;
 }
 
 export async function readNoticeApi(
   noticeId: string,
 ): Promise<CommonResponseType<NoticeArticle>> {
-  try {
-    const response = await axiosInstance.get<NoticeApiResponse>(
-      `/notices/${noticeId}`,
-    );
+  const response = await axiosInstance.get<NoticeApiResponse>(
+    `/notices/${noticeId}`,
+  );
 
-    return response.data;
-  } catch (error) {
-    console.error("API 호출 실패:", error);
-    throw new Error("질문 데이터를 가져오는 중 문제가 발생했습니다.");
-  }
+  return response.data;
 }
 
 export async function readApprovalApi(
   projectId: number,
   approvalId: number,
 ): Promise<ApprovalArticle> {
-  try {
-    const response = await axiosInstance.get<ApprovalApiResponse>(
-      `${BASE_URL}/projects/${projectId}/approvals/${approvalId}`,
-    );
+  const response = await axiosInstance.get<ApprovalApiResponse>(
+    `${BASE_URL}/projects/${projectId}/approvals/${approvalId}`,
+  );
 
-    return response.data.data;
-  } catch (error) {
-    throw new Error("결재 데이터를 가져오는 중 문제가 발생했습니다.");
-  }
+  return response.data.data;
 }
 
 // 결재 서명 막기 위해 내 정보 불러오기
 export async function getMyOrgId() {
-  try {
-    const response = await axiosInstance.get(`${BASE_URL}/me`);
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
+  const response = await axiosInstance.get(`${BASE_URL}/me`);
+  return response.data;
 }
 
 export async function resolveQuestion(projectId: number, questionId: number) {
-  try {
-    const response = await axiosInstance.post(`/projects/${projectId}/questions/${questionId}/resolve`)
-    return response.data;
-  } catch (error) {
-    console.error(error)
-  }
+  const response = await axiosInstance.post(
+    `/projects/${projectId}/questions/${questionId}/resolve`,
+  );
+  return response.data;
 }
 
 export async function getProjectInfo(projectId: number) {
-  try {
-    const response = await axiosInstance.get(`/projects/${projectId}/project-info`)
-    return response.data;
-  } catch (error) {
-    console.error(error)
-  }
+  const response = await axiosInstance.get(
+    `/projects/${projectId}/project-info`,
+  );
+  return response.data;
 }

--- a/src/api/RegisterArticle.ts
+++ b/src/api/RegisterArticle.ts
@@ -2,35 +2,27 @@ import axiosInstance from "@/src/api/axiosInstance";
 import { QuestionRequestData, ApprovalRequestData } from "@/src/types";
 
 export async function uploadFileApi(file: File) {
-  try {
-    const formData = new FormData();
-    formData.append("file", file);
+  const formData = new FormData();
+  formData.append("file", file);
 
-    const response = await axiosInstance.post("/file", formData, {
-      headers: {
-        "Content-type": "multipart/form-data",
-      },
-    });
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
+  const response = await axiosInstance.post("/file", formData, {
+    headers: {
+      "Content-type": "multipart/form-data",
+    },
+  });
+  return response.data;
 }
 
 export async function uploadContentFileApi(file: File) {
-  try {
-    const formData = new FormData();
-    formData.append("file", file);
+  const formData = new FormData();
+  formData.append("file", file);
 
-    const response = await axiosInstance.post("/file/public", formData, {
-      headers: {
-        "Content-type": "multipart/form-data",
-      },
-    });
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
+  const response = await axiosInstance.post("/file/public", formData, {
+    headers: {
+      "Content-type": "multipart/form-data",
+    },
+  });
+  return response.data;
 }
 
 // 질문글 생성
@@ -45,20 +37,8 @@ export async function createQuestionApi(
   return response.data;
 }
 
-// 결재글 생성
-export async function createTaskApi(
-  projectId: number,
-  requestData: ApprovalRequestData,
-) {
-  const response = await axiosInstance.post(
-    `/projects/${projectId}/approvals`,
-    requestData,
-  );
-  return response.data;
-}
-
 // 질문글 수정
-export async function editQuestionAPI(
+export async function updateQuestionApi(
   projectId: number,
   questionId: number,
   requestData: QuestionRequestData,
@@ -72,19 +52,26 @@ export async function editQuestionAPI(
 
 // 질문글 삭제
 export async function deleteQuestionApi(projectId: number, questionId: number) {
-  try {
-    const response = await axiosInstance.delete(
-      `projects/${projectId}/questions/${questionId}`,
-    );
-    return response.data;
-  } catch (error) {
-    console.error("캐치에러", error);
-    throw new Error("댓글 삭제 실패");
-  }
+  const response = await axiosInstance.delete(
+    `projects/${projectId}/questions/${questionId}`,
+  );
+  return response.data;
+}
+
+// 결재글 생성
+export async function createApprovalApi(
+  projectId: number,
+  requestData: ApprovalRequestData,
+) {
+  const response = await axiosInstance.post(
+    `/projects/${projectId}/approvals`,
+    requestData,
+  );
+  return response.data;
 }
 
 // 결재글 수정
-export async function editApprovalAPI(
+export async function editApprovalApi(
   projectId: number,
   approvalId: number,
   requestData: ApprovalRequestData,
@@ -98,13 +85,8 @@ export async function editApprovalAPI(
 
 // 결재글 삭제
 export async function deleteApprovalApi(projectId: number, approvalId: number) {
-  try {
-    const response = await axiosInstance.delete(
-      `projects/${projectId}/approvals/${approvalId}`,
-    );
-    return response.data;
-  } catch (error) {
-    console.error("캐치에러", error);
-    throw new Error("댓글 삭제 실패");
-  }
+  const response = await axiosInstance.delete(
+    `projects/${projectId}/approvals/${approvalId}`,
+  );
+  return response.data;
 }

--- a/src/api/commentAPI.ts
+++ b/src/api/commentAPI.ts
@@ -1,24 +1,16 @@
 import axiosInstance from "@/src/api/axiosInstance";
-import { showToast } from "@/src/utils/showToast";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-
 export async function deleteQuestionComment(
-
   projectId: number,
   questionId: number,
   commentId: number,
 ) {
-  try {
-    const response = await axiosInstance.delete(
-      `${BASE_URL}/projects/${projectId}/questions/${questionId}/comments/${commentId}`,
-    );
-    return response.data;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  const response = await axiosInstance.delete(
+    `${BASE_URL}/projects/${projectId}/questions/${questionId}/comments/${commentId}`,
+  );
+  return response.data;
 }
 
 export async function deleteApprovalComment(
@@ -26,34 +18,24 @@ export async function deleteApprovalComment(
   approvalId: number,
   commentId: number,
 ) {
-  try {
-    const response = await axiosInstance.delete(
-      `${BASE_URL}/projects/${projectId}/approvals/${approvalId}/comments/${commentId}`,
-    );
+  const response = await axiosInstance.delete(
+    `${BASE_URL}/projects/${projectId}/approvals/${approvalId}/comments/${commentId}`,
+  );
 
-    return response.data;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response.data;
 }
 
 export async function editQuestionComment(
   projectId: number,
   questionId: number,
   commentId: number,
-  requestData: any
+  requestData: any,
 ) {
-  try {
-    const response = await axiosInstance.put(
-      `${BASE_URL}/projects/${projectId}/questions/${questionId}/comments/${commentId}`,
-      requestData,
-    );
-    return response.data
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  const response = await axiosInstance.put(
+    `${BASE_URL}/projects/${projectId}/questions/${questionId}/comments/${commentId}`,
+    requestData,
+  );
+  return response.data;
 }
 
 export async function editApprovalComment(
@@ -61,16 +43,10 @@ export async function editApprovalComment(
   approvalId: number,
   commentId: number,
   requestData: any,
-) { 
-  try {
-    const response = await axiosInstance.put(
-      `${BASE_URL}/projects/${projectId}/approvals/${approvalId}/comments/${commentId}`,
-      requestData,
-    );
-    return response.data
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+) {
+  const response = await axiosInstance.put(
+    `${BASE_URL}/projects/${projectId}/approvals/${approvalId}/comments/${commentId}`,
+    requestData,
+  );
+  return response.data;
 }
-

--- a/src/api/members.ts
+++ b/src/api/members.ts
@@ -64,14 +64,10 @@ export async function fetchOrganizationMemberListApi(
  * @returns
  */
 export async function fetchMembersWithinOrgApi(organizationId: string) {
-  try {
-    const response = await axiosInstance.get(
-      `/admins/members/member/org/${organizationId}`,
-    );
-    return response.data;
-  } catch (error) {
-    throw error;
-  }
+  const response = await axiosInstance.get(
+    `/admins/members/member/org/${organizationId}`,
+  );
+  return response.data;
 }
 
 // 📌 회원 상세 정보 가져오기
@@ -133,39 +129,27 @@ export async function deleteMemberApi(
   memberId: string,
   reason: string,
 ): Promise<CommonResponseType<DeleteMemberResponse>> {
-  try {
-    const response = await axiosInstance.post(
-      `/admins/members/delete/${memberId}`,
-      { reason }, // 🔹 요청 바디에 탈퇴 사유 추가
-    );
-    return response.data; // ✅ 응답 데이터 반환
-  } catch (error) {
-    throw error; // 🚨 에러 발생 시 throw
-  }
+  const response = await axiosInstance.post(
+    `/admins/members/delete/${memberId}`,
+    { reason }, // 🔹 요청 바디에 탈퇴 사유 추가
+  );
+  return response.data; // ✅ 응답 데이터 반환
 }
 
 export async function activateMemberApi(
   memberId: string,
-): Promise<ActivateMemberResponse> {
-  try {
-    const response = await axiosInstance.post(
-      `/admins/members/activate?memberId=${memberId}`,
-    );
-    return response.data;
-  } catch (error) {
-    throw error; // 🚨 에러 발생 시 throw
-  }
+): Promise<CommonResponseType<ActivateMemberResponse>> {
+  const response = await axiosInstance.post(
+    `/admins/members/activate?memberId=${memberId}`,
+  );
+  return response.data;
 }
 
 export async function deactivateMemberApi(
   memberId: string,
-): Promise<DeactivateMemberResponse> {
-  try {
-    const response = await axiosInstance.post(
-      `/admins/members/deactivate?memberId=${memberId}`,
-    );
-    return response.data;
-  } catch (error) {
-    throw error; // 🚨 에러 발생 시 throw
-  }
+): Promise<CommonResponseType<DeactivateMemberResponse>> {
+  const response = await axiosInstance.post(
+    `/admins/members/deactivate?memberId=${memberId}`,
+  );
+  return response.data;
 }

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -25,13 +25,8 @@ import {
 export async function createProjectApi(
   requestData: any,
 ): Promise<CommonResponseType<CreateProjectResponse>> {
-  try {
-    const response = await axiosInstance.post("/admins/projects", requestData);
-    return response.data;
-  } catch (error) {
-    console.error("프로젝트 생성 실패", error);
-    throw error;
-  }
+  const response = await axiosInstance.post("/admins/projects", requestData);
+  return response.data;
 }
 
 /**
@@ -44,16 +39,11 @@ export async function updateProjectApi(
   projectId: string,
   requestData: any,
 ): Promise<CommonResponseType<CreateProjectResponse>> {
-  try {
-    const response = await axiosInstance.patch(
-      `/admins/projects/${projectId}`,
-      requestData,
-    );
-    return response.data;
-  } catch (error) {
-    console.error("프로젝트 수정 실패", error);
-    throw error;
-  }
+  const response = await axiosInstance.patch(
+    `/admins/projects/${projectId}`,
+    requestData,
+  );
+  return response.data;
 }
 
 /**

--- a/src/api/signature.ts
+++ b/src/api/signature.ts
@@ -2,31 +2,21 @@ import axiosInstance from "@/src/api/axiosInstance";
 import { SignApiResponse } from "@/src/types";
 
 export async function bringSignApi() {
-  try {
-    const response =
-      await axiosInstance.get<SignApiResponse>(`/members/signatures`);
+  const response =
+    await axiosInstance.get<SignApiResponse>(`/members/signatures`);
 
-    return response.data;
-  } catch (error) {
-    console.error("API 호출 실패", error);
-    throw new Error("서명 유무 데이터를 가져오는 중 문제가 발생했습니다.");
-  }
+  return response.data;
 }
 
 export async function sendSignApi(file: File) {
-  try {
-    const formData = new FormData();
-    formData.append("file", file);
+  const formData = new FormData();
+  formData.append("file", file);
 
-    const response = await axiosInstance.post(`/members/signatures`, formData, {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    });
+  const response = await axiosInstance.post(`/members/signatures`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
 
-    return response.data;
-  } catch (error) {
-    console.error("서명 이미지 업로드 실패", error);
-    throw new Error("서명 이미지 업로드 중 오류가 발생했습니다.");
-  }
+  return response.data;
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -70,7 +70,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <Box
             as="main"
             {...layoutStyles.mainContent(isSidebarOpen, isListPage)}
-            mb={"30rem"}
           >
             {!isListPage ? <BackButton /> : <></>}
             {children}

--- a/src/components/common/CommentBox.tsx
+++ b/src/components/common/CommentBox.tsx
@@ -84,6 +84,7 @@ export default function CommentBox({
         value={commentText}
         maxLength={250}
         maxHeight={"100px"}
+        autoresize
       />
       <Flex justifyContent="flex-end">
         <Button

--- a/src/components/common/CommentItem.tsx
+++ b/src/components/common/CommentItem.tsx
@@ -197,6 +197,7 @@ export default function CommentItem({
               overflowWrap: "break-word",
               whiteSpace: "pre-wrap",
             }}
+            autoresize
           />
         ) : (
           <Text

--- a/src/components/common/InputForm.tsx
+++ b/src/components/common/InputForm.tsx
@@ -99,14 +99,6 @@ export default function InputForm({
             <span className={styles.required}>*</span>
           )}
         </label>
-        {/* {!["연락처", "로그인 Password", "로그인 Email"].includes(label) && (
->>>>>>> main
-          <Text pl={4}>
-            {`${value.length} / `}
-            {maxLength}
-          </Text>
-
-        )} */}
       </Flex>
       {/* 주소 입력 필드 - 클릭 시 검색 모달 오픈 */}
       {type === "address" ? (

--- a/src/components/pages/AdminMembersCreatePage/components/SelectOrganization.tsx
+++ b/src/components/pages/AdminMembersCreatePage/components/SelectOrganization.tsx
@@ -64,7 +64,9 @@ export default function SelectedOrganization({
                 _hover={{ bg: "blue.200", color: "white" }}
                 onClick={() => setSelectedOrganization(org)}
               >
-                <Text>{org.name}</Text>
+                <Text>
+                  {org.name}({org.type})
+                </Text>
               </Box>
             ))
           ) : (

--- a/src/components/pages/AdminMembersCreatePage/index.tsx
+++ b/src/components/pages/AdminMembersCreatePage/index.tsx
@@ -215,26 +215,37 @@ export default function AdminMembersCreatePage() {
                     />
                     <Box maxHeight="15rem" overflowY="auto">
                       {organizations?.length > 0 ? (
-                        organizations.map((org, index) => (
-                          <Box
-                            key={org.id}
-                            ref={(el: HTMLDivElement | null) =>
-                              (listRefs.current[index] = el)
-                            }
-                            p="3"
-                            borderRadius={"md"}
-                            bg={highlightedIndex === index ? "blue.500" : ""}
-                            color={
-                              highlightedIndex === index ? "white" : "black"
-                            }
-                            cursor="pointer"
-                            mb="2"
-                            _hover={{ bg: "blue.200", color: "white" }}
-                            onClick={() => handleSelectOrganization(org.id)}
-                          >
-                            <Text>{org.name}</Text>
-                          </Box>
-                        ))
+                        organizations.map(
+                          (org, index) =>
+                            org.status === "ACTIVE" && (
+                              <Box
+                                key={org.id}
+                                ref={(el: HTMLDivElement | null) =>
+                                  (listRefs.current[index] = el)
+                                }
+                                p="3"
+                                borderRadius={"md"}
+                                bg={
+                                  highlightedIndex === index ? "blue.500" : ""
+                                }
+                                color={
+                                  highlightedIndex === index ? "white" : "black"
+                                }
+                                cursor="pointer"
+                                mb="2"
+                                _hover={{ bg: "blue.200", color: "white" }}
+                                onClick={() => handleSelectOrganization(org.id)}
+                              >
+                                <Text>
+                                  {org.name}
+                                  &nbsp;
+                                  {org.type === "CUSTOMER"
+                                    ? "(고객사)"
+                                    : "(개발사)"}
+                                </Text>
+                              </Box>
+                            ),
+                        )
                       ) : (
                         <Text>조회된 회사가 없습니다.</Text>
                       )}

--- a/src/components/pages/LoginPage/index.tsx
+++ b/src/components/pages/LoginPage/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Box, Button, Text } from "@chakra-ui/react";
 import { login } from "@/src/api/auth";
@@ -27,16 +27,6 @@ export default function LoginPage() {
   const { inputValues, inputErrors, handleInputChange, checkAllInputs } =
     useForm(defaultValuesOfLogin, validationRulesOfLogin);
 
-  useEffect(() => {
-    // MAC 시스템 다크모드 사용자 설정 감지
-    const darkMode = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    document.body.className = darkMode ? "dark" : "light";
-    // 로그인 시 기존 데이터 초기화
-    localStorage.removeItem("user");
-    localStorage.removeItem("selectedProjectFilter");
-  }, []);
-
-  // #TODO 차크라UI 컴포넌트 사용 - 에러메시지 또는 로딩 UI
   function validateLoginInputs() {
     if (!checkAllInputs()) {
       alert("입력값을 확인하세요.");

--- a/src/components/pages/NoticesPage/index.tsx
+++ b/src/components/pages/NoticesPage/index.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   Heading,
   Table,
+  Text,
 } from "@chakra-ui/react";
 import CommonTable from "@/src/components/common/CommonTable";
 import SearchSection from "@/src/components/common/SearchSection";
@@ -257,7 +258,13 @@ function NoticesPageContent() {
                     {(notice.updatedAt ?? "-").split(" ")[0]}
                   </Table.Cell>
                   <Table.Cell {...(isEmergency ? EMERGENCY_STYLE : {})}>
-                    {NOTICE_STATUS_LABELS[notice.isDeleted]}
+                    {notice.isDeleted === "Y" ? (
+                      <Text color="red">
+                        {NOTICE_STATUS_LABELS[notice.isDeleted]}
+                      </Text>
+                    ) : (
+                      <>{NOTICE_STATUS_LABELS[notice.isDeleted]}</>
+                    )}
                   </Table.Cell>
                   <Table.Cell onClick={(event) => event.stopPropagation()}>
                     {notice.isDeleted !== "Y" ? (

--- a/src/components/pages/ProjectApprovalEditPage/components/EditSignUpload.tsx
+++ b/src/components/pages/ProjectApprovalEditPage/components/EditSignUpload.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Button, Image, Text } from "@chakra-ui/react";
 import { bringSignApi, sendSignApi } from "@/src/api/signature";
 import SignaturePad from "signature_pad";
 import DropDownInfoTop from "@/src/components/common/DropDownInfoTop";
+import { showToast } from "@/src/utils/showToast";
 
 interface EditSignUploadProps {
   signatureUrl: string;
@@ -11,7 +12,6 @@ interface EditSignUploadProps {
 export default function EditSignUpload({ signatureUrl }: EditSignUploadProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [signaturePad, setSignaturePad] = useState<SignaturePad | null>(null);
-
   const [yourSignatureUrl, setYourSignatureUrl] =
     useState<string>(signatureUrl);
 
@@ -35,7 +35,14 @@ export default function EditSignUpload({ signatureUrl }: EditSignUploadProps) {
   // 서명 저장
   const saveSignature = async () => {
     if (!signaturePad || signaturePad.isEmpty()) {
-      alert("서명을 입력하세요");
+      const errorMessage = "서명을 입력하세요.";
+      showToast({
+        title: "요청 실패",
+        description: errorMessage,
+        type: "error",
+        duration: 3000,
+        error: errorMessage,
+      });
       return;
     }
     const signatureData = signaturePad.toDataURL("image/png");
@@ -55,7 +62,14 @@ export default function EditSignUpload({ signatureUrl }: EditSignUploadProps) {
       const responseData = await sendSignApi(file);
       setYourSignatureUrl(responseData.data.url);
     } catch (error) {
-      console.error("서명 등록 실패", error);
+      const errorMessage = "서명 등록에 실패했습니다.";
+      showToast({
+        title: "요청 실패",
+        description: errorMessage,
+        type: "error",
+        duration: 3000,
+        error: errorMessage,
+      });
     }
   };
 
@@ -69,7 +83,14 @@ export default function EditSignUpload({ signatureUrl }: EditSignUploadProps) {
         signaturePad.fromDataURL(responseData.data.signatureUrl);
       }
     } catch (error) {
-      console.error("서명 불러오는데 오류 발생", error);
+      const errorMessage = "서명을 불러오는데 오류가 발생했습니다.";
+      showToast({
+        title: "요청 실패",
+        description: errorMessage,
+        type: "error",
+        duration: 3000,
+        error: errorMessage,
+      });
     }
   };
 

--- a/src/components/pages/ProjectApprovalPage/components/SignToApprove.tsx
+++ b/src/components/pages/ProjectApprovalPage/components/SignToApprove.tsx
@@ -208,7 +208,7 @@ export default function SignToApprove({
       console.log(error);
     }
   };
-  console.log(myName, customerOwnerName)
+  console.log(myName, customerOwnerName);
   return (
     <Flex direction={"column"} align="center">
       <Flex direction="column" align="center">

--- a/src/components/pages/ProjectApprovalPage/index.tsx
+++ b/src/components/pages/ProjectApprovalPage/index.tsx
@@ -13,11 +13,11 @@ import CommentBox from "@/src/components/common/CommentBox";
 import { readApprovalApi, getProjectInfo } from "@/src/api/ReadArticle";
 import SignToApprove from "@/src/components/pages/ProjectApprovalPage/components/SignToApprove";
 import { ArticleComment, ApprovalArticle } from "@/src/types";
-import { deleteApprovalApi } from "@/src/api/RegisterArticle";
 import { getMeApi } from "@/src/api/getMembersApi";
 import DropDownMenu from "@/src/components/common/DropDownMenu";
 import DropDownInfoBottom from "../../common/DropDownInfoBottom";
 import { showToast } from "@/src/utils/showToast";
+import { useDeleteApproval } from "@/src/hook/useMutationData";
 
 export default function ProjectApprovalPage() {
   const { projectId, approvalId } = useParams() as {
@@ -39,6 +39,8 @@ export default function ProjectApprovalPage() {
   const [myOrgId, setMyOrgId] = useState<number>();
   const [myName, setMyName] = useState<string>("");
   const [customerOwnerName, setCustomerOwnerName] = useState<string>("");
+  const { mutate: deleteApproval, error: approvalDeleteError } =
+    useDeleteApproval();
 
   useEffect(() => {
     const loadApproval = async () => {
@@ -52,9 +54,9 @@ export default function ProjectApprovalPage() {
           Number(approvalId),
         );
 
-        const responseDataOfProject = await getProjectInfo(Number(projectId))
+        const responseDataOfProject = await getProjectInfo(Number(projectId));
 
-        setCustomerOwnerName(responseDataOfProject.data.customerOwnerName)
+        setCustomerOwnerName(responseDataOfProject.data.customerOwnerName);
 
         setArticle(responseData);
         setCategory(responseData.category);
@@ -92,9 +94,6 @@ export default function ProjectApprovalPage() {
     return <Box>로딩 중...</Box>;
   }
 
-  console.log(myName);
-  console.log(myOrgId);
-
   const handleEdit = () => {
     if (approverSignatureUrl !== undefined) {
       const errorMessage = "결재가 완료된 글은 수정할 수 없습니다.";
@@ -125,35 +124,14 @@ export default function ProjectApprovalPage() {
 
     const confirmDelete = window.confirm("정말로 삭제하시겠습니까?");
     if (!confirmDelete) return;
-    try {
-      const response = await deleteApprovalApi(
-        Number(projectId),
-        Number(approvalId),
-      );
-      if (response.message) {
-        showToast({
-          title: "요청 성공",
-          description: response.message,
-          type: "success",
-          duration: 3000,
-        });
-      }
-      router.push(`/projects/${projectId}/approvals`);
-    } catch (error: any) {
-      const errorMessage =
-        error.response?.data?.message ||
-        error.message ||
-        "결재 글 삭제 중 중 오류가 발생했습니다.";
 
-      // ✅ 토스트로 사용자에게 알림
-      showToast({
-        title: "요청 실패",
-        description: errorMessage,
-        type: "error",
-        duration: 3000,
-        error: errorMessage,
-      });
-    }
+    const response = await deleteApproval(
+      Number(projectId),
+      Number(approvalId),
+    );
+    if (response === null) return;
+
+    router.push(`/projects/${projectId}/approvals`);
   };
   // test
   return (
@@ -167,7 +145,6 @@ export default function ProjectApprovalPage() {
       borderRadius="lg"
       boxShadow="md"
     >
-
       {/* 게시글 내용 */}
       <Flex justifyContent={"space-between"}>
         <Button
@@ -185,8 +162,8 @@ export default function ProjectApprovalPage() {
           <DropDownMenu onEdit={handleEdit} onDelete={handleDelete} />
         ) : null}
       </Flex>
-      {/* 게시글 내용 */}
 
+      {/* 게시글 내용 */}
       <ArticleContent article={article} />
 
       <Box display={"flex"} direction={"row"} alignItems={"center"}>
@@ -205,7 +182,7 @@ export default function ProjectApprovalPage() {
           registerOrgId={registerOrgId}
         />
       </Box>
-      
+
       {/* 댓글 섹션 */}
       <VStack align="stretch" gap={8} mt={10}>
         <ArticleComments

--- a/src/components/pages/ProjectApprovalsPage/index.tsx
+++ b/src/components/pages/ProjectApprovalsPage/index.tsx
@@ -22,6 +22,7 @@ import ErrorAlert from "@/src/components/common/ErrorAlert";
 import { getMeApi } from "@/src/api/getMembersApi";
 import { useProjectApprovalProgressStepData } from "@/src/hook/useFetchData";
 import { useProjectApprovalList } from "@/src/hook/useFetchBoardList";
+import { showToast } from "@/src/utils/showToast";
 
 const approvalStatusFramework = createListCollection<{
   id: string;
@@ -97,7 +98,14 @@ export default function ProjectApprovalsPage() {
 
   const handleProjectApprovalCreateButton = () => {
     if (myOrgType === "CUSTOMER") {
-      alert("결재 글은 개발사만 작성이 가능합니다.");
+      const errorMessage = "결재 글은 개발사만 작성이 가능합니다.";
+      showToast({
+        title: "요청 실패",
+        description: errorMessage,
+        type: "error",
+        duration: 3000,
+        error: errorMessage,
+      });
       return;
     }
     router.push(`/projects/${projectId}/approvals/new`);

--- a/src/components/pages/ProjectQuestionsPage/index.tsx
+++ b/src/components/pages/ProjectQuestionsPage/index.tsx
@@ -115,14 +115,7 @@ export default function ProjectQuestionsPage() {
         {projectQuestionError && (
           <ErrorAlert message="프로젝트 질문 목록을 불러오지 못했습니다. 다시 시도해주세요." />
         )}
-        {/* 
-          CommonTable: 게시글 목록을 렌더링하는 공통 테이블 컴포넌트
-          - headerTitle: 테이블 헤더
-          - data: 목록 데이터
-          - loading: 로딩 상태
-          - renderRow: 각 행의 셀을 어떻게 렌더링할지 정의
-          - handleRowClick: 행 클릭 시 동작
-        */}
+
         <CommonTable
           skeletonCount={4}
           colspan={6}

--- a/src/components/pages/ProjectWorkFlowPage/components/AddProgressStepModal.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/AddProgressStepModal.tsx
@@ -12,7 +12,7 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { debounce } from "lodash";
-import { Palette, Plus, RefreshCcw } from "lucide-react";
+import { Palette, RefreshCcw } from "lucide-react";
 import { SketchPicker, ColorResult } from "react-color";
 import CustomModal from "@/src/components/pages/ProjectWorkFlowPage/components/CustomModal";
 import { useCreateProjectProgressStep } from "@/src/hook/useMutationData";
@@ -114,6 +114,7 @@ export default function AddProgressStepModal({
               placeholder="이 단계에 대한 설명을 입력하세요."
               value={stepDescription}
               onChange={(e) => setStepDescription(e.target.value)}
+              autoresize
             />
           </Box>
 

--- a/src/components/pages/ProjectWorkFlowPage/components/EditProgressStepModal.tsx
+++ b/src/components/pages/ProjectWorkFlowPage/components/EditProgressStepModal.tsx
@@ -131,6 +131,7 @@ export default function EditProgressStepModal({
               placeholder="이 단계에 대한 설명을 입력하세요."
               value={stepDescription}
               onChange={(e) => setStepDescription(e.target.value)}
+              autoresize
             />
           </Box>
 

--- a/src/components/pages/ProjectsCreatePage/components/ContentSection.tsx
+++ b/src/components/pages/ProjectsCreatePage/components/ContentSection.tsx
@@ -65,7 +65,7 @@ export default function ContentSection({
           borderRadius="0.5rem"
           p="0.75rem"
           width="100%"
-          height="5rem"
+          minHeight="5rem"
           overflowY="auto"
           onInput={(e) => {
             const target = e.target as HTMLTextAreaElement;

--- a/src/components/pages/ProjectsCreatePage/components/OrganizationSelector.tsx
+++ b/src/components/pages/ProjectsCreatePage/components/OrganizationSelector.tsx
@@ -281,7 +281,6 @@ export default function OrganizationSelector({
                   border="1px solid #ccc"
                   borderRadius="0.5rem"
                   p="0.75rem"
-                  mb="1rem"
                   width="100%"
                 />
                 <Box maxHeight="20rem" overflowY="auto">

--- a/src/components/pages/ProjectsCreatePage/components/ProjectForm.tsx
+++ b/src/components/pages/ProjectsCreatePage/components/ProjectForm.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateProject,
 } from "@/src/hook/useMutationData";
 import DateSection from "@/src/components/pages/ProjectsCreatePage/components/DateSection";
+import { showToast } from "@/src/utils/showToast";
 
 interface ProjectFormProps {
   projectData?: ProjectDetailProps; // projectData가 있을 경우 수정 모드
@@ -87,7 +88,6 @@ export default function ProjectForm({
       const data = await fetchMembersWithinOrgApi(organizationId);
       setMembers(data.data?.members || []);
     } catch (error) {
-      console.error(error);
       setMembers([]);
     }
   };
@@ -144,34 +144,84 @@ export default function ProjectForm({
 
     // 필수 정보
     if (formData.name.length < 2) {
-      alert("프로젝트명을 2글자 이상 입력해주세요.");
+      const errorMessage = "프로젝트명을 2글자 이상 입력해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (formData.description.length < 2) {
-      alert("프로젝트 개요를 2글자 이상 입력해주세요.");
+      const errorMessage = "프로젝트 개요를 2글자 이상 입력해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.startAt) {
-      alert("프로젝트 시작일을 선택해주세요.");
+      const errorMessage = "프로젝트 시작일을 선택해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.deadlineAt) {
-      alert("프로젝트 종료일을 선택해주세요.");
+      const errorMessage = "프로젝트 예정 마감일을 선택해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.customerOrgId) {
-      alert("고객사를 지정해주세요.");
+      const errorMessage = "고객사를 지정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.developerOrgId) {
-      alert("개발사를 지정해주세요.");
+      const errorMessage = "개발사를 지정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (selectedCustomerMembers.length === 0) {
-      alert("고객사 담당자 회원을 배정해주세요.");
+      const errorMessage = "고객사 담당자 회원을 배정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (selectedDeveloperMembers.length === 0) {
-      alert("개발사 담당자 회원을 배정해주세요.");
+      const errorMessage = "개발사 담당자 회원을 배정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.customerOwnerId) {
-      alert("고객사 Owner 을 설정해주세요.");
+      const errorMessage = "고객사 Owner을 지정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     } else if (!formData.devOwnerId) {
-      alert("개발사 Owner 을 설정해주세요.");
+      const errorMessage = "개발사 Owner을 지정해주세요.";
+      showToast({
+        title: "필수 입력정보 ",
+        description: errorMessage,
+        duration: 2000,
+      });
       return;
     }
 
@@ -183,15 +233,6 @@ export default function ProjectForm({
     };
 
     if (isEditMode) {
-      console.log("수정 요청 - requestBody: ", requestBody);
-      console.log(
-        "수정 요청(시작일 타입) - requestBody: ",
-        typeof requestBody.startAt,
-      );
-      console.log(
-        "수정 요청(예상마감일 타입) - requestBody: ",
-        typeof requestBody.deadlineAt,
-      );
       const response = await updateProject(projectId, requestBody);
 
       if (response === null) return;

--- a/src/hook/useMutationData.ts
+++ b/src/hook/useMutationData.ts
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { showToast } from "@/src/utils/showToast";
 import {
+  ActivateMemberResponse,
+  ApprovalRequestData,
   CommonResponseType,
   CreateMemberInput,
   CreateMemberResponse,
   CreateOrganizationInput,
   CreateOrganizationResponse,
   CreateProjectResponse,
+  DeactivateMemberResponse,
   DeleteMemberResponse,
   DeleteOrganizationResponse,
   MemberProps,
@@ -15,6 +18,7 @@ import {
   ProgressAddProps,
   ProgressStep,
   ProgressStepOrder,
+  QuestionRequestData,
 } from "@/src/types";
 import {
   createNoticeApi,
@@ -39,10 +43,20 @@ import {
   updateOrganizationApi,
 } from "@/src/api/organizations";
 import {
+  activateMemberApi,
   createMemberApi,
+  deactivateMemberApi,
   deleteMemberApi,
   updateMemberApi,
 } from "@/src/api/members";
+import {
+  createApprovalApi,
+  createQuestionApi,
+  deleteApprovalApi,
+  deleteQuestionApi,
+  editApprovalApi,
+  updateQuestionApi,
+} from "@/src/api/RegisterArticle";
 
 interface UseMutationDataProps<T, P extends any[]> {
   mutationApi: (...args: P) => Promise<CommonResponseType<T>>;
@@ -129,6 +143,24 @@ export function useUpdateMember() {
 export function useDeleteMember() {
   return useMutationData<DeleteMemberResponse, [string, string]>({
     mutationApi: deleteMemberApi,
+  });
+}
+
+/**
+ * 회원 상태 활성화로 변경 훅
+ */
+export function useActivateMemberStatus() {
+  return useMutationData<ActivateMemberResponse, [string]>({
+    mutationApi: activateMemberApi,
+  });
+}
+
+/**
+ * 회원 상태 비활성화로 변경 훅
+ */
+export function useDeactivateMemberStatus() {
+  return useMutationData<DeactivateMemberResponse, [string]>({
+    mutationApi: deactivateMemberApi,
   });
 }
 
@@ -278,5 +310,59 @@ export function useUpdateProjectProgressStep() {
 export function useUpdateProjectManagementStep() {
   return useMutationData<void, [string, string]>({
     mutationApi: projectManagementStepApi,
+  });
+}
+
+/**
+ * 결재 게시글 생성 훅
+ */
+export function useCreateApproval() {
+  return useMutationData<void, [number, ApprovalRequestData]>({
+    mutationApi: createApprovalApi,
+  });
+}
+
+/**
+ * 결재 게시글 수정 훅
+ */
+export function useUpdateApproval() {
+  return useMutationData<void, [number, number, ApprovalRequestData]>({
+    mutationApi: editApprovalApi,
+  });
+}
+
+/**
+ * 결재 게시글 삭제 훅
+ */
+export function useDeleteApproval() {
+  return useMutationData<void, [number, number]>({
+    mutationApi: deleteApprovalApi,
+  });
+}
+
+/**
+ * 질문 게시글 생성 훅
+ */
+export function useCreateQuestion() {
+  return useMutationData<void, [number, QuestionRequestData]>({
+    mutationApi: createQuestionApi,
+  });
+}
+
+/**
+ * 질문 게시글 수정 훅
+ */
+export function useUpdateQuestion() {
+  return useMutationData<void, [number, number, QuestionRequestData]>({
+    mutationApi: updateQuestionApi,
+  });
+}
+
+/**
+ * 질문 게시글 삭제 훅
+ */
+export function useDeleteQuestion() {
+  return useMutationData<void, [number, number]>({
+    mutationApi: deleteQuestionApi,
   });
 }

--- a/src/utils/showToast.ts
+++ b/src/utils/showToast.ts
@@ -15,7 +15,7 @@ export const showToast = ({
   }
   // 중복 체크: 동일한 description이 존재하는 경우 새 토스트 생성 안 함
   if (toastMessages.has(description)) return;
-  
+
   // 토스트 메시지 Set에 추가
   toastMessages.add(description);
 


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 : [FEATURE][CHORE] alert 구문 toast 메시지로 변경 및 UI/UX 개선
- Related to #234 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->

### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] import 시 의도를 명확히 하기 위해 별칭 작성 (예: Provider as ChakraProvider)
- [ ] 컴포넌트를 함수형 컴포넌트로 선언 (예: export default function 컴포넌트명() {})
- [ ] 컴포넌트명은 파스칼 케이스로 작성
- [ ] 변수명 및 함수명은 카멜케이스로 작성하며 식별 가능하도록 명확히 작성 (예: renderMenuByMemberRole)
- [ ] React Hook 사용 순서는 useRef > useState > useEffect > useMemo > useCallback 순서 준수
- [ ] Import 순서는 아래와 같이 정리
      [1. 외부 라이브러리 (react, axios 등) 2. 절대 경로 파일 (@components, @utils 등) 3. 스타일 파일 (.css, .scss 등)]
- [ ] Props 인터페이스는 ‘컴포넌트명’ + Props로 명명 (예: ButtonProps, UserProfileProps)
- [ ] 렌더링과 관련 없는 정적 데이터는 컴포넌트 외부에 선언
- [ ] 상수는 별도의 파일에 모아 관리
- [ ] 공통적인 유틸리티 함수(예: 시간 변환, 문자열 변환)는 utils 폴더에 정리
- [ ] 공통 타입은 types 폴더에서 관리 (공통이 아닌 타입은 페이지 폴더 내부에 작성)
- [ ] 별도 페이지에서만 사용하는 컴포넌트는 해당 pages의 폴더 > components 폴더에 배치
- [ ] 여러 페이지에서 사용하는 공통 컴포넌트는 common 폴더로 이동 (도메인별로 구분)
- [ ] 외부 의존성 최소화하고 순수 함수로 작성
- [ ] 사용하지 않는 임포트문이나 기타 파일들 삭제
- [ ] 주석 성실히 작성
- [ ] 빌드하고 PR 날리기
